### PR TITLE
Create QML module, the Qt6.2+ way

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
   ```sh
   git clone https://github.com/moritzstoetter/qt6purchasing.git
   ```
-2. Move 'android/GooglePlayBilling.java' to `QT_ANDROID_PACKAGE_SOURCE_DIR/src/com/COMPANY_NAME/APP_NAME/GooglePlayBilling.java`
+2. Copy 'android/GooglePlayBilling.java' to `QT_ANDROID_PACKAGE_SOURCE_DIR/src/com/COMPANY_NAME/APP_NAME/GooglePlayBilling.java`
   For more information on how to include custom Java-Code in your Android App see [Deploying an Application on Android](https://doc.qt.io/qt-6/deployment-android.html).
 3. Add the qt6purchasing Library to your Project. In your project's `CMakeLists.txt` add the following:
    ```cmake

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
    target_link_libraries(APP_TARGET
        PRIVATE
            ...
-           qt6purchasingplugin
+           qt6purchasinglibplugin
    )
    ```
 

--- a/README.md
+++ b/README.md
@@ -105,44 +105,14 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
   ```
 2. Copy 'android/GooglePlayBilling.java' to `QT_ANDROID_PACKAGE_SOURCE_DIR/src/com/COMPANY_NAME/APP_NAME/GooglePlayBilling.java`
   For more information on how to include custom Java-Code in your Android App see [Deploying an Application on Android](https://doc.qt.io/qt-6/deployment-android.html).
-3. Add the qt6purchasing Library to your Project. In your project's `CMakeLists.txt` add the following:
+3. Add the qt6purchasing library's QML plugin to your project. In your project's `CMakeLists.txt` add the following:
    ```cmake
-   target_link_libraries(APP_NAME
-    PRIVATE
-        ...
-        store
-    )
-    ```
-4. Expose the purchasing classes to QML. In your `main.cpp` include the following lines:
-  ```cpp
-  #if defined Q_OS_ANDROID
-  #include <QJniObject>
-  #include <QCoreApplication>
-  #include "backend/store/android/googleplaystorebackend.h"
-  #include "backend/store/android/googleplaystoreproduct.h"
-  #include "backend/store/android/googleplaystoretransaction.h"
-  #endif
-
-  #if defined Q_OS_DARWIN
-  #include "backend/store/apple/appleappstorebackend.h"
-  #include "backend/store/apple/appleappstoreproduct.h"
-  #include "backend/store/apple/appleappstoretransaction.h"
-  #endif
-
-  ...
-
-  qmlRegisterUncreatableType<AbstractStoreBackend>("AbstractStoreBackend",1,0,"AbstractStoreBackend","AbstractProduct uncreatable");
-  qmlRegisterUncreatableType<AbstractProduct>("AbstractProduct",1,0,"AbstractProduct","AbstractProduct uncreatable");
-  qmlRegisterUncreatableType<AbstractTransaction>("AbstractTransaction",1,0,"AbstractTransaction","AbstractTransaction uncreatable");
-#if defined Q_OS_ANDROID
-  qmlRegisterType<GooglePlayStoreBackend>("Store", 1, 0, "Store");
-  qmlRegisterType<GooglePlayStoreProduct>("Product", 1, 0, "Product");
-#elif defined Q_OS_DARWIN
-  qmlRegisterType<AppleAppStoreBackend>("Store", 1, 0, "Store");
-  qmlRegisterType<AppleAppStoreProduct>("Product", 1, 0, "Product");
-#endif
-  ```
-
+   target_link_libraries(APP_TARGET
+       PRIVATE
+           ...
+           qt6purchasingplugin
+   )
+   ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -151,19 +121,18 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
 <!-- USAGE EXAMPLES -->
 ## Usage
 
-1. In your QML file include the purchasing classes:
+1. In your QML file include the purchasing module:
   ```qml
-  import Store
-  import Product  
+  import Qt6Purchasing
   ```
 2. Use it like this, for a product that is called "test_1" in the app store(s):
   ```qml
-  Store {
+  Qt6Purchasing.Store {
     id: iapStore
-    Product {
+    Qt6Purchasing.Product {
       id: testingProduct
       identifier: "test_1"
-      type: Product.Consumable
+      type: Qt6Purchasing.Product.Consumable
     }
   }
 
@@ -176,12 +145,11 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
   ```
   `StoreItem.qml`:
   ```qml
-  import QtQuick
-  import Product
+  import Qt6Purchasing
 
   Item {
     id: root
-    required property Product product
+    required property Qt6Purchasing.Product product
 
     signal iapCompleted
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
 
 ### Prerequisites
 
-* Qt/QML 6
+* Qt/QML 6 (6.8 or higher)
 * Apple StoreKit
 * Android Billing Client
 
@@ -106,13 +106,22 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
 2. Copy 'android/GooglePlayBilling.java' to `QT_ANDROID_PACKAGE_SOURCE_DIR/src/com/COMPANY_NAME/APP_NAME/GooglePlayBilling.java`
   For more information on how to include custom Java-Code in your Android App see [Deploying an Application on Android](https://doc.qt.io/qt-6/deployment-android.html).
 3. Add the qt6purchasing library's QML plugin to your project. In your project's `CMakeLists.txt` add the following:
-   ```cmake
-   target_link_libraries(APP_TARGET
-       PRIVATE
-           ...
-           qt6purchasinglibplugin
-   )
-   ```
+   1. Ensure your project applies Qt 6.8 policies.
+      ```cmake
+	  qt_standard_project_setup(REQUIRES 6.8)
+      ```
+   2. Make this library's QML components available in the same build folder as all your own.
+      ```
+	  set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+      ```
+   3. Link your app target to this library's QML module.
+      ```cmake
+      target_link_libraries(APP_TARGET
+          PRIVATE
+              ...
+              qt6purchasinglibplugin
+      )
+      ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,26 +68,28 @@ set(CORE_HEADERS
     include/qt6purchasing/abstracttransaction.h
 )
 
-qt_add_library(qt6purchasing STATIC
+qt_add_library(qt6purchasinglib STATIC
         ${CORE_SOURCES}
         ${CORE_HEADERS}
         ${PLATFORM_SOURCES}
         ${PLATFORM_HEADERS}
 )
 
-qt_add_qml_module(qt6purchasing
+qt_add_qml_module(qt6purchasinglib
     URI Qt6Purchasing
+    RESOURCE_PREFIX /
     VERSION 1.0
+    OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/qml/Qt6Purchasing"
 )
 
-target_include_directories(qt6purchasing
+target_include_directories(qt6purchasinglib
     PRIVATE
         ${PLATFORM_INCLUDE}
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
-target_link_libraries(qt6purchasing
+target_link_libraries(qt6purchasinglib
     PRIVATE
         Qt6::Core
     PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,11 @@ qt_add_library(qt6purchasing STATIC
         ${PLATFORM_HEADERS}
 )
 
+qt_add_qml_module(qt6purchasing
+    URI Qt6Purchasing
+    VERSION 1.0
+)
+
 target_include_directories(qt6purchasing
     PRIVATE
         ${PLATFORM_INCLUDE}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,8 @@ find_package(Qt6 6.8 REQUIRED COMPONENTS
     Qml
 )
 
-qt_standard_project_setup()
+qt_standard_project_setup(REQUIRES 6.8)
+set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 # Platform-specific sources and libraries
 set(PLATFORM_LIBS "")
@@ -77,9 +78,7 @@ qt_add_library(qt6purchasinglib STATIC
 
 qt_add_qml_module(qt6purchasinglib
     URI Qt6Purchasing
-    RESOURCE_PREFIX /
     VERSION 1.0
-    OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/qml/Qt6Purchasing"
 )
 
 target_include_directories(qt6purchasinglib

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -10,9 +10,8 @@ AbstractStoreBackend::AbstractStoreBackend(QObject * parent) : QObject(parent)
 
     qDebug() << "Creating store backend";
 
-    connect(this, &AbstractStoreBackend::connectedChanged, [this](bool connected) {
-        _connected = connected;
-        if (connected) {
+    connect(this, &AbstractStoreBackend::connectedChanged, [this]() {
+        if (isConnected()) {
             qDebug() << "Connected to store";
             qDebug() << "Found" << _products.size() << "product(s) awaiting registration";
             for (AbstractProduct * product : _products) {
@@ -58,6 +57,16 @@ AbstractStoreBackend::AbstractStoreBackend(QObject * parent) : QObject(parent)
             qCritical() << "Failed to map consumed purchase to a product!";
         }
     });
+}
+
+void AbstractStoreBackend::setConnected(bool connected)
+{
+    if (_connected == connected)
+        return;
+
+    _connected = connected;
+    emit connectedChanged();
+    qDebug() << "Store connection status changed to" << (_connected ? "connected" : "disconnected");
 }
 
 AbstractProduct * AbstractStoreBackend::product(const QString &identifier)

--- a/src/abstracttransaction.cpp
+++ b/src/abstracttransaction.cpp
@@ -2,14 +2,11 @@
 #include <qt6purchasing/abstracttransaction.h>
 #include <QJsonObject>
 
-AbstractTransaction::AbstractTransaction(AbstractStoreBackend * store, QString orderId) : QObject(),
-    _store(store),
+AbstractTransaction::AbstractTransaction(QString orderId, QObject * parent) : QObject(parent),
     _orderId(orderId)
 {
-    if (this->thread() != _store->thread())
-        this->moveToThread(_store->thread());
-
-    this->setParent(_store);
+    _store = qobject_cast<AbstractStoreBackend*>(parent);
+    Q_ASSERT(_store);
 }
 
 void AbstractTransaction::finalize()

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -47,7 +47,7 @@ GooglePlayStoreBackend::GooglePlayStoreBackend(QObject * parent) : AbstractStore
 
 /*static*/ void GooglePlayStoreBackend::connectedChangedHelper(JNIEnv * env, jobject object, jboolean connected)
 {
-    emit GooglePlayStoreBackend::instance()->connectedChanged(connected);
+    GooglePlayStoreBackend::instance()->setConnected(connected);
 }
 
 void GooglePlayStoreBackend::startConnection()

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -110,7 +110,7 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
 {
     QJsonObject json = QJsonDocument::fromJson(env->GetStringUTFChars(message, nullptr)).object();
 
-    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(AbstractStoreBackend::instance(), json);
+    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(json, AbstractStoreBackend::instance());
     emit GooglePlayStoreBackend::instance()->purchaseSucceeded(transaction);
 }
 
@@ -118,7 +118,7 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
 {
     QJsonObject json = QJsonDocument::fromJson(env->GetStringUTFChars(message, nullptr)).object();
 
-    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(AbstractStoreBackend::instance(), json);
+    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(json, AbstractStoreBackend::instance());
     emit GooglePlayStoreBackend::instance()->purchaseRestored(transaction);
 }
 
@@ -131,7 +131,7 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
 {
     QJsonObject json = QJsonDocument::fromJson(env->GetStringUTFChars(message, nullptr)).object();
 
-    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(AbstractStoreBackend::instance(), json);
+    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(json, AbstractStoreBackend::instance());
     emit GooglePlayStoreBackend::instance()->purchaseConsumed(transaction);
 }
 

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -10,7 +10,7 @@
 class GooglePlayStoreBackend : public AbstractStoreBackend
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Store)
 
 public:
     enum BillingResponseCode {

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -10,6 +10,7 @@
 class GooglePlayStoreBackend : public AbstractStoreBackend
 {
     Q_OBJECT
+	QML_ELEMENT
 
 public:
     enum BillingResponseCode {

--- a/src/android/googleplaystoreproduct.h
+++ b/src/android/googleplaystoreproduct.h
@@ -9,7 +9,7 @@ class GooglePlayStoreBackend;
 class GooglePlayStoreProduct : public AbstractProduct
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Product)
 
 public:
     GooglePlayStoreProduct(QObject * parent = nullptr);

--- a/src/android/googleplaystoreproduct.h
+++ b/src/android/googleplaystoreproduct.h
@@ -9,6 +9,7 @@ class GooglePlayStoreBackend;
 class GooglePlayStoreProduct : public AbstractProduct
 {
     Q_OBJECT
+	QML_ELEMENT
 
 public:
     GooglePlayStoreProduct(QObject * parent = nullptr);

--- a/src/android/googleplaystoretransaction.cpp
+++ b/src/android/googleplaystoretransaction.cpp
@@ -1,6 +1,6 @@
 #include "googleplaystoretransaction.h"
 
-GooglePlayStoreTransaction::GooglePlayStoreTransaction(AbstractStoreBackend * store, QJsonObject json) : AbstractTransaction(store, json["orderId"].toString()),
+GooglePlayStoreTransaction::GooglePlayStoreTransaction(QJsonObject json, QObject * parent) : AbstractTransaction(json["orderId"].toString(), parent),
     _json(json)
 {}
 

--- a/src/android/googleplaystoretransaction.h
+++ b/src/android/googleplaystoretransaction.h
@@ -7,6 +7,7 @@ class GooglePlayStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
     QML_NAMED_ELEMENT(Transaction)
+    QML_UNCREATABLE("Transactions are created by the store backend")
 
 public:
     GooglePlayStoreTransaction(QJsonObject json, QObject * parent = nullptr);

--- a/src/android/googleplaystoretransaction.h
+++ b/src/android/googleplaystoretransaction.h
@@ -9,7 +9,7 @@ class GooglePlayStoreTransaction : public AbstractTransaction
     QML_NAMED_ELEMENT(Transaction)
 
 public:
-    GooglePlayStoreTransaction(AbstractStoreBackend * store, QJsonObject json);
+    GooglePlayStoreTransaction(QJsonObject json, QObject * parent = nullptr);
 
     QString productId() const override;
     QJsonObject json() const { return _json; }

--- a/src/android/googleplaystoretransaction.h
+++ b/src/android/googleplaystoretransaction.h
@@ -6,6 +6,8 @@
 class GooglePlayStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
+	QML_ELEMENT
+
 public:
     GooglePlayStoreTransaction(AbstractStoreBackend * store, QJsonObject json);
 

--- a/src/android/googleplaystoretransaction.h
+++ b/src/android/googleplaystoretransaction.h
@@ -6,7 +6,7 @@
 class GooglePlayStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Transaction)
 
 public:
     GooglePlayStoreTransaction(AbstractStoreBackend * store, QJsonObject json);

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -3,9 +3,7 @@
 
 #include <qt6purchasing/abstractstorebackend.h>
 
-Q_FORWARD_DECLARE_OBJC_CLASS(QT_MANGLE_NAMESPACE(InAppPurchaseManager));
-
-QT_BEGIN_NAMESPACE
+Q_FORWARD_DECLARE_OBJC_CLASS(InAppPurchaseManager);
 
 class AppleAppStoreBackend : public AbstractStoreBackend
 {
@@ -20,10 +18,8 @@ public:
 
 //    void emitProductRegistered(AbstractProduct * product);
 private:
-    QT_MANGLE_NAMESPACE(InAppPurchaseManager) * _iapManager = nullptr;
+    InAppPurchaseManager * _iapManager = nullptr;
 
 };
-
-QT_END_NAMESPACE
 
 #endif // APPLEAPPSTOREBACKEND_H

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -7,6 +7,9 @@ Q_FORWARD_DECLARE_OBJC_CLASS(InAppPurchaseManager);
 
 class AppleAppStoreBackend : public AbstractStoreBackend
 {
+    Q_OBJECT
+	QML_ELEMENT
+
 public:
     AppleAppStoreBackend(QObject * parent = nullptr);
     ~AppleAppStoreBackend();

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -8,7 +8,7 @@ Q_FORWARD_DECLARE_OBJC_CLASS(InAppPurchaseManager);
 class AppleAppStoreBackend : public AbstractStoreBackend
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Store)
 
 public:
     AppleAppStoreBackend(QObject * parent = nullptr);

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -122,7 +122,7 @@ void AppleAppStoreBackend::startConnection()
             [InAppPurchaseManager alloc]
             initWithBackend:this
     ];
-    emit connectedChanged(true);
+    setConnected(_iapManager != nullptr);
 }
 
 void AppleAppStoreBackend::registerProduct(AbstractProduct * product)

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -87,7 +87,7 @@
 {
     Q_UNUSED(queue);
     for (SKPaymentTransaction * transaction in transactions) {
-        AppleAppStoreTransaction * ta = new AppleAppStoreTransaction(backend, transaction);
+        AppleAppStoreTransaction * ta = new AppleAppStoreTransaction(transaction, backend);
 
         switch (static_cast<AppleAppStoreTransaction::AppleAppStoreTransactionState>(transaction.transactionState)) {
         case AppleAppStoreTransaction::Purchasing:

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -7,7 +7,7 @@
 
 #import <StoreKit/StoreKit.h>
 
-@interface QT_MANGLE_NAMESPACE(InAppPurchaseManager) : NSObject <SKProductsRequestDelegate, SKPaymentTransactionObserver>
+@interface InAppPurchaseManager : NSObject <SKProductsRequestDelegate, SKPaymentTransactionObserver>
 {
     AppleAppStoreBackend * backend;
     NSMutableArray<SKPaymentTransaction *> *pendingTransactions;
@@ -17,7 +17,7 @@
 
 @end
 
-@implementation QT_MANGLE_NAMESPACE(InAppPurchaseManager)
+@implementation InAppPurchaseManager
 
 -(id)initWithBackend:(AppleAppStoreBackend *)iapBackend {
     if (self = [super init]) {
@@ -119,7 +119,7 @@ AppleAppStoreBackend::AppleAppStoreBackend(QObject * parent) : AbstractStoreBack
 void AppleAppStoreBackend::startConnection()
 {
     _iapManager = [
-            [QT_MANGLE_NAMESPACE(InAppPurchaseManager) alloc]
+            [InAppPurchaseManager alloc]
             initWithBackend:this
     ];
     emit connectedChanged(true);

--- a/src/apple/appleappstoreproduct.h
+++ b/src/apple/appleappstoreproduct.h
@@ -8,7 +8,7 @@ Q_FORWARD_DECLARE_OBJC_CLASS(SKProduct);
 class AppleAppStoreProduct : public AbstractProduct
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Product)
 
 public:
     AppleAppStoreProduct(QObject * parent = nullptr);

--- a/src/apple/appleappstoreproduct.h
+++ b/src/apple/appleappstoreproduct.h
@@ -8,6 +8,7 @@ Q_FORWARD_DECLARE_OBJC_CLASS(SKProduct);
 class AppleAppStoreProduct : public AbstractProduct
 {
     Q_OBJECT
+	QML_ELEMENT
 
 public:
     AppleAppStoreProduct(QObject * parent = nullptr);

--- a/src/apple/appleappstoretransaction.h
+++ b/src/apple/appleappstoretransaction.h
@@ -9,6 +9,7 @@ class AppleAppStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
     QML_NAMED_ELEMENT(Transaction)
+    QML_UNCREATABLE("Transactions are created by the store backend")
 
 public:
     enum AppleAppStoreTransactionState {

--- a/src/apple/appleappstoretransaction.h
+++ b/src/apple/appleappstoretransaction.h
@@ -8,6 +8,8 @@ Q_FORWARD_DECLARE_OBJC_CLASS(SKPaymentTransaction);
 class AppleAppStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
+	QML_ELEMENT
+
 public:
     enum AppleAppStoreTransactionState {
         Purchasing,

--- a/src/apple/appleappstoretransaction.h
+++ b/src/apple/appleappstoretransaction.h
@@ -19,7 +19,7 @@ public:
         Deferred
     };
     Q_ENUM(AppleAppStoreTransactionState)
-    AppleAppStoreTransaction(AbstractStoreBackend * store, SKPaymentTransaction * transaction);
+    AppleAppStoreTransaction(SKPaymentTransaction * transaction, QObject * parent = nullptr);
 
     QString productId() const override;
     SKPaymentTransaction * nativeTransaction() { return _nativeTransaction; }

--- a/src/apple/appleappstoretransaction.h
+++ b/src/apple/appleappstoretransaction.h
@@ -8,7 +8,7 @@ Q_FORWARD_DECLARE_OBJC_CLASS(SKPaymentTransaction);
 class AppleAppStoreTransaction : public AbstractTransaction
 {
     Q_OBJECT
-	QML_ELEMENT
+    QML_NAMED_ELEMENT(Transaction)
 
 public:
     enum AppleAppStoreTransactionState {

--- a/src/apple/appleappstoretransaction.mm
+++ b/src/apple/appleappstoretransaction.mm
@@ -2,7 +2,7 @@
 
 #import <StoreKit/StoreKit.h>
 
-AppleAppStoreTransaction::AppleAppStoreTransaction(AbstractStoreBackend * store, SKPaymentTransaction * transaction) : AbstractTransaction(store, QString::fromNSString(transaction.transactionIdentifier)),
+AppleAppStoreTransaction::AppleAppStoreTransaction(SKPaymentTransaction * transaction, QObject * parent) : AbstractTransaction(QString::fromNSString(transaction.transactionIdentifier), parent),
     _nativeTransaction(transaction)
 {}
 

--- a/src/include/qt6purchasing/abstractproduct.h
+++ b/src/include/qt6purchasing/abstractproduct.h
@@ -2,6 +2,7 @@
 #define ABSTRACTPRODUCT_H
 
 #include <QObject>
+#include <QQmlEngine>
 #include <qt6purchasing/abstractstorebackend.h>
 
 class AbstractTransaction;
@@ -9,6 +10,9 @@ class AbstractTransaction;
 class AbstractProduct : public QObject
 {
     Q_OBJECT
+    QML_NAMED_ELEMENT(AbstractProduct)
+    QML_UNCREATABLE("AbstractProduct is an abstract base class")
+
     // writable properties
     Q_PROPERTY(QString identifier READ identifier WRITE setIdentifier NOTIFY identifierChanged REQUIRED)
     Q_PROPERTY(ProductType type READ productType WRITE setProductType NOTIFY productTypeChanged REQUIRED)

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -17,6 +17,7 @@ class AbstractStoreBackend : public QObject
 
     Q_PROPERTY(QQmlListProperty<AbstractProduct> productsQml READ productsQml)
     Q_CLASSINFO("DefaultProperty", "productsQml")
+    Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged FINAL)
 
 public:
     static AbstractStoreBackend * instance() { return _instance; }
@@ -36,8 +37,10 @@ protected:
     QList<AbstractProduct *> _products;
     bool _connected = false;
 
+    void setConnected(bool connected);
+
 signals:
-    void connectedChanged(bool connected);
+    void connectedChanged();
     void productRegistered(AbstractProduct * product);
     void purchaseSucceeded(AbstractTransaction * transaction);
     void purchaseRestored(AbstractTransaction * transaction);

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -3,6 +3,7 @@
 
 #include <QJsonDocument>
 #include <QObject>
+#include <QQmlEngine>
 #include <QQmlListProperty>
 
 class AbstractProduct;
@@ -11,6 +12,9 @@ class AbstractTransaction;
 class AbstractStoreBackend : public QObject
 {
     Q_OBJECT
+    QML_NAMED_ELEMENT(AbstractStoreBackend)
+    QML_UNCREATABLE("AbstractStoreBackend is an abstract base class")
+
     Q_PROPERTY(QQmlListProperty<AbstractProduct> productsQml READ productsQml)
     Q_CLASSINFO("DefaultProperty", "productsQml")
 

--- a/src/include/qt6purchasing/abstracttransaction.h
+++ b/src/include/qt6purchasing/abstracttransaction.h
@@ -3,12 +3,16 @@
 
 #include <QJsonObject>
 #include <QObject>
+#include <QQmlEngine>
 
 class AbstractStoreBackend;
 
 class AbstractTransaction : public QObject
 {
     Q_OBJECT
+    QML_NAMED_ELEMENT(AbstractTransaction)
+    QML_UNCREATABLE("AbstractTransaction is an abstract base class")
+
     Q_PROPERTY(int status READ status NOTIFY statusChanged)
     Q_PROPERTY(QString orderId READ orderId CONSTANT)
 

--- a/src/include/qt6purchasing/abstracttransaction.h
+++ b/src/include/qt6purchasing/abstracttransaction.h
@@ -32,7 +32,7 @@ public:
     Q_INVOKABLE void finalize();
 
 protected:
-    explicit AbstractTransaction(AbstractStoreBackend * store, QString orderId);
+    explicit AbstractTransaction(QString orderId, QObject * parent = nullptr);
     AbstractStoreBackend * _store = nullptr;
     int _status;
     QString _orderId;


### PR DESCRIPTION
Completes implementation and resolves #6.

As of Qt 6.2, there is a new, streamlined (and recommended) way of registering QML types from C++ classes:
- Use the Qt CMake command `qt_add_qml_module`.
- Within a class, use the new macros, such as `QML_ELEMENT`.
- That's it!

I have applied this approach and I've updated the README to take out the step editing `main.cpp`.

Note that in QML you now import a single module:
```
import Qt6Purchasing
```
and this imports all the classes.
You can then instantiate `Store` and `Product` (and use `Transaction`). If you want to be more precise and avoid naming collisions, you can specify the module name too; eg. `Qt6Purchasing.Store` etc.