### PR TITLE
In Obj-C (Apple), use ARC exclusively

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,6 +55,15 @@ elseif(APPLE)
     )
 
     set(PLATFORM_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/apple)
+
+    # Ensure ARC is enabled for Objective-C++ files
+    set_source_files_properties(
+        apple/appleappstorebackend.mm
+        apple/appleappstoreproduct.mm
+        apple/appleappstoretransaction.mm
+        PROPERTIES
+        COMPILE_FLAGS "-fobjc-arc"
+    )
 endif()
 
 # The public-facing library

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -34,8 +34,6 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
 -(void)dealloc
 {
     [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
-    [pendingTransactions release];
-    [super dealloc];
 }
 
 -(void)requestProductData:(NSString *)identifier
@@ -74,7 +72,6 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
             [numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
             [numberFormatter setLocale:skProduct.priceLocale];
             NSString * localizedPrice = [numberFormatter stringFromNumber:skProduct.price];
-            [numberFormatter release];
 
             product->setNativeProduct(skProduct);
             product->setDescription(QString::fromNSString(skProduct.localizedDescription));
@@ -136,8 +133,6 @@ AppleAppStoreBackend::~AppleAppStoreBackend()
 {
     if (s_currentInstance == this)
         s_currentInstance = nullptr;
-
-    [_iapManager release];
 }
 
 void AppleAppStoreBackend::startConnection()

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -56,7 +56,7 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
     }
 
     NSArray<SKProduct *> * skProducts = response.products;
-    SKProduct * skProduct = [skProducts count] == 1 ? [[skProducts firstObject] retain] : nil;
+    SKProduct * skProduct = [skProducts count] == 1 ? [skProducts firstObject] : nil;
 
     if (skProduct == nil) {
         //Invalid product ID
@@ -85,11 +85,7 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
             QMetaObject::invokeMethod(backend, "productRegistered", Qt::AutoConnection, Q_ARG(AbstractProduct*, product));
         } else {
         }
-
-        [skProduct release];
     }
-
-    [request release];
 }
 
 //SKPaymentTransactionObserver


### PR DESCRIPTION
Partially implements #11.

The code was mixing manual memory management and ARC.

- CMake: enforce ARC
- Obj-C: remove all manual memory management.