### PR TITLE
Avoid accumulating transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,6 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
   }
   ```
 
-**Important**: It is your responsibility to destroy the `transaction` objects received on the pro
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
-
 
 ## Thread Safety
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,22 @@ To add In-App-Purchasing capabilities to your Qt6/QML project follow the steps b
     }
   }
   ```
+3. **Note**: Transactions will automatically be destroyed after your handler completes. If for some reason you want to hold onto a `transaction`, call `retain()` immediately and then call `destroy()` when you're done.
+  ```qml
+  Connections {
+      target: product
+      function onPurchaseConsumed(transaction) {
+          transaction.retain() // Retain transaction while we do deferred work
+          
+          Qt.callLater(function() {
+              // Update user preferences, analytics, etc.
+              transaction.destroy()
+          })
+      }
+  }
+  ```
 
+**Important**: It is your responsibility to destroy the `transaction` objects received on the pro
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 

--- a/src/abstracttransaction.cpp
+++ b/src/abstracttransaction.cpp
@@ -17,3 +17,15 @@ void AbstractTransaction::finalize()
     qDebug() << "Transaction: Finalizing purchase" << this->_orderId;
     _store->consumePurchase(this);
 }
+
+void AbstractTransaction::retain()
+{
+    _retained = true;
+    qDebug() << "Transaction retained:" << _orderId;
+}
+
+void AbstractTransaction::destroy()
+{
+    qDebug() << "Transaction destroyed:" << _orderId;
+    deleteLater();
+}

--- a/src/include/qt6purchasing/abstracttransaction.h
+++ b/src/include/qt6purchasing/abstracttransaction.h
@@ -30,12 +30,15 @@ public:
     virtual QString productId() const = 0;
 
     Q_INVOKABLE void finalize();
+    Q_INVOKABLE void retain();
+    Q_INVOKABLE void destroy();
 
 protected:
     explicit AbstractTransaction(QString orderId, QObject * parent = nullptr);
     AbstractStoreBackend * _store = nullptr;
     int _status;
     QString _orderId;
+    bool _retained = false;
 
 signals:
     void statusChanged();
@@ -43,4 +46,3 @@ signals:
 };
 
 #endif // ABSTRACTTRANSACTION_H
-


### PR DESCRIPTION
Partially implements #11.

Although an app will typically only end up with a handful of transactions, it's possible for the restored purchases to contain a sizeable history. (I accept that the objects are small and so this is not a big issue.)

- Transactions are created for signals `purchaseXxxx(transaction)`
- In a slot (usually QML) the transaction can just be used, or if it is needed beyond the current event loop it can be `retain()`ed and later `destroy()`ed.
- In the `AbstractStoreBackend` slots, setup in the constructor, any unretained transactions are queued for deletion at the end of the following event loop.
- README updated with an example.