### PR TITLE
Migrate Apple backend from StoreKit 1 to StoreKit 2

### DIFF
--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -61,13 +61,13 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
         }
 
         Product * nativeProduct = [products firstObject];
-        AppleAppStoreProduct * qtProduct = reinterpret_cast<AppleAppStoreProduct*>(backend->product(QString::fromNSString(nativeProduct.id)));
+        AppleAppStoreProduct * qtProduct = reinterpret_cast<AppleAppStoreProduct*>(backend->product(QString::fromNSString([nativeProduct id])));
 
         if (qtProduct) {
             qtProduct->setNativeProduct(nativeProduct);
-            qtProduct->setDescription(QString::fromNSString(nativeProduct.description));
-            qtProduct->setPrice(QString::fromNSString(nativeProduct.displayPrice));
-            qtProduct->setTitle(QString::fromNSString(nativeProduct.displayName));
+            qtProduct->setDescription(QString::fromNSString([nativeProduct description]));
+            qtProduct->setPrice(QString::fromNSString([nativeProduct displayPrice]));
+            qtProduct->setTitle(QString::fromNSString([nativeProduct displayName]));
             qtProduct->setStatus(AbstractProduct::Registered);
 
             QMetaObject::invokeMethod(backend, "productRegistered", Qt::AutoConnection, Q_ARG(AbstractProduct*, qtProduct));
@@ -90,12 +90,12 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
             if ([transaction verifyTransaction]) {
                 AppleAppStoreTransaction * ta = new AppleAppStoreTransaction(transaction, backend);
 
-                switch (transaction.transactionState) {
+                switch ([transaction transactionState]) {
                 case TransactionStatePurchased:
                     QMetaObject::invokeMethod(backend, "purchaseSucceeded", Qt::AutoConnection, Q_ARG(AbstractTransaction*, ta));
                     break;
                 case TransactionStateFailed:
-                    QMetaObject::invokeMethod(backend, "purchaseFailed", Qt::AutoConnection, Q_ARG(int, transaction.error.code));
+                    QMetaObject::invokeMethod(backend, "purchaseFailed", Qt::AutoConnection, Q_ARG(int, [[transaction error] code]));
                     break;
                 case TransactionStateRestored:
                     QMetaObject::invokeMethod(backend, "purchaseRestored", Qt::AutoConnection, Q_ARG(AbstractTransaction*, ta));
@@ -105,7 +105,7 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
                     break;
                 }
             } else {
-                qWarning() << "Transaction verification failed for transaction ID:" << transaction.id;
+                qWarning() << "Transaction verification failed for transaction ID:" << [transaction originalTransactionID];
             }
         }
     }];
@@ -147,9 +147,9 @@ void AppleAppStoreBackend::purchaseProduct(AbstractProduct * product)
     if (nativeProduct) {
         [Product purchaseProduct:nativeProduct completionHandler:^(Product * _Nullable purchasedProduct, NSError * _Nullable error) {
             if (error) {
-                QMetaObject::invokeMethod(this, "purchaseFailed", Qt::AutoConnection, Q_ARG(int, error.code));
+                QMetaObject::invokeMethod(this, "purchaseFailed", Qt::AutoConnection, Q_ARG(int, [error code]));
             } else {
-                qDebug() << "Purchase initiated for product:" << QString::fromNSString(purchasedProduct.id);
+                qDebug() << "Purchase initiated for product:" << QString::fromNSString([purchasedProduct id]);
             }
         }];
     } else {

--- a/src/apple/appleappstoreproduct.h
+++ b/src/apple/appleappstoreproduct.h
@@ -3,7 +3,7 @@
 
 #include <qt6purchasing/abstractproduct.h>
 
-Q_FORWARD_DECLARE_OBJC_CLASS(SKProduct);
+Q_FORWARD_DECLARE_OBJC_CLASS(Product);
 
 class AppleAppStoreProduct : public AbstractProduct
 {
@@ -13,11 +13,11 @@ class AppleAppStoreProduct : public AbstractProduct
 public:
     AppleAppStoreProduct(QObject * parent = nullptr);
 
-    SKProduct * nativeProduct() { return _nativeProduct; }
-    void setNativeProduct(SKProduct * np);
+    Product * nativeProduct() { return _nativeProduct; }
+    void setNativeProduct(Product * product);
 
 private:
-    SKProduct * _nativeProduct = nullptr;
+    Product * _nativeProduct = nullptr;
 };
 
 #endif // APPLEAPPSTOREPRODUCT_H

--- a/src/apple/appleappstoreproduct.mm
+++ b/src/apple/appleappstoreproduct.mm
@@ -3,7 +3,7 @@
 AppleAppStoreProduct::AppleAppStoreProduct(QObject * parent) : AbstractProduct(parent)
 {}
 
-void AppleAppStoreProduct::setNativeProduct(SKProduct * np)
+void AppleAppStoreProduct::setNativeProduct(Product * product)
 {
-    _nativeProduct = np;
+    _nativeProduct = product;
 }

--- a/src/apple/appleappstoretransaction.h
+++ b/src/apple/appleappstoretransaction.h
@@ -3,7 +3,7 @@
 
 #include <qt6purchasing/abstracttransaction.h>
 
-Q_FORWARD_DECLARE_OBJC_CLASS(SKPaymentTransaction);
+Q_FORWARD_DECLARE_OBJC_CLASS(Transaction);
 
 class AppleAppStoreTransaction : public AbstractTransaction
 {
@@ -12,21 +12,13 @@ class AppleAppStoreTransaction : public AbstractTransaction
     QML_UNCREATABLE("Transactions are created by the store backend")
 
 public:
-    enum AppleAppStoreTransactionState {
-        Purchasing,
-        Purchased,
-        Failed,
-        Restored,
-        Deferred
-    };
-    Q_ENUM(AppleAppStoreTransactionState)
-    AppleAppStoreTransaction(SKPaymentTransaction * transaction, QObject * parent = nullptr);
+    AppleAppStoreTransaction(Transaction * transaction, QObject * parent = nullptr);
 
     QString productId() const override;
-    SKPaymentTransaction * nativeTransaction() { return _nativeTransaction; }
+    Transaction * nativeTransaction() { return _nativeTransaction; }
 
 private:
-    SKPaymentTransaction * _nativeTransaction;
+    Transaction * _nativeTransaction = nullptr;
 };
 
 #endif // APPLEAPPSTORETRANSACTION_H

--- a/src/apple/appleappstoretransaction.mm
+++ b/src/apple/appleappstoretransaction.mm
@@ -2,11 +2,14 @@
 
 #import <StoreKit/StoreKit.h>
 
-AppleAppStoreTransaction::AppleAppStoreTransaction(SKPaymentTransaction * transaction, QObject * parent) : AbstractTransaction(QString::fromNSString(transaction.transactionIdentifier), parent),
+AppleAppStoreTransaction::AppleAppStoreTransaction(Transaction * transaction, QObject * parent) : AbstractTransaction(QString::number(transaction.id), parent),
     _nativeTransaction(transaction)
 {}
 
 QString AppleAppStoreTransaction::productId() const
 {
-    return QString::fromNSString(_nativeTransaction.payment.productIdentifier);
+    if (_nativeTransaction) {
+        return QString::fromNSString(_nativeTransaction.productID);
+    }
+    return QString();
 }

--- a/src/apple/appleappstoretransaction.mm
+++ b/src/apple/appleappstoretransaction.mm
@@ -2,14 +2,14 @@
 
 #import <StoreKit/StoreKit.h>
 
-AppleAppStoreTransaction::AppleAppStoreTransaction(Transaction * transaction, QObject * parent) : AbstractTransaction(QString::number(transaction.id), parent),
+AppleAppStoreTransaction::AppleAppStoreTransaction(Transaction * transaction, QObject * parent) : AbstractTransaction(QString::number([transaction originalTransactionID]), parent),
     _nativeTransaction(transaction)
 {}
 
 QString AppleAppStoreTransaction::productId() const
 {
     if (_nativeTransaction) {
-        return QString::fromNSString(_nativeTransaction.productID);
+        return QString::fromNSString([_nativeTransaction productID]);
     }
     return QString();
 }


### PR DESCRIPTION
Implements and resolves #1.

## Summary

This PR migrates the iOS implementation from the deprecated StoreKit 1 to the modern StoreKit 2 framework, leveraging Qt 6.8's iOS 16+ requirement to drop legacy compatibility code.

## Key API Changes: StoreKit 1 → StoreKit 2

### Product Requests

**StoreKit 1 (Delegate Pattern):**
```
// Create request object
SKProductsRequest * request = [[SKProductsRequest alloc] initWithProductIdentifiers:productIds];
request.delegate = self;
[request start];

// Handle response in separate delegate method
-(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
    // Process SKProduct objects
    // Manual price formatting with NSNumberFormatter
}
```

**StoreKit 2 (Completion Handler):**
```
// Single call with inline completion
[Product productsForIdentifiers:productIds completionHandler:^(NSArray<Product *> * products, NSError * error) {
    // Process Product objects directly
    // Pre-formatted pricing via product.displayPrice
}];
```

### Transaction Handling

**StoreKit 1 (Observer Protocol):**
```
// Implement SKPaymentTransactionObserver protocol
- (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
    // Manual state checking
    // Manual transaction finishing
    [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
}
```

**StoreKit 2 (Block-based Observer):**
```
// Modern block-based observation
[Transaction addTransactionObserver:^(NSArray<Transaction *> * transactions) {
    // Automatic transaction verification
    if ([transaction verifyTransaction]) {
        // Automatic finishing - no manual intervention needed
    }
}];
```

## Purchase Flow

**StoreKit 1:**
```
SKPayment * payment = [SKPayment paymentWithProduct:skProduct];
[[SKPaymentQueue defaultQueue] addPayment:payment];
```

**StoreKit 2:**
```
[Product purchaseProduct:product completionHandler:^(Product * purchasedProduct, NSError * error) {
    // Handle result directly
}];
```

## Benefits of StoreKit 2 Approach

1. Simplified Architecture: Eliminates request/response objects and delegate protocols
2. Modern Async Patterns: Block-based completion handlers instead of delegate callbacks
3. Automatic Verification: Built-in transaction verification with JWS tokens
4. Pre-formatted Data: displayPrice provides localized currency strings
5. Better Error Handling: Structured error types and cleaner error propagation
6. Reduced Boilerplate: Fewer objects and protocols to manage
7. Future-proof: Apple's recommended path forward (StoreKit 1 deprecated at WWDC 2024)

## Implementation Changes

- Removed: SKProduct, SKPaymentTransaction, SKProductsRequest, SKPaymentQueue usage
- Added: StoreKit 2 Product and Transaction objects with modern APIs
- Simplified: Naming conventions (nativeProduct vs storeKit2Product)
- Cleaned: Empty line whitespace and improved variable naming consistency

## Test Plan (needs creating)

- Product registration on iOS 16+ devices
- Purchase flow with real App Store products
- Transaction verification and completion
- Error handling for invalid products and failed purchases
- Restoration of previous purchases
