### PR TITLE
Fix purchaseFailed signal propagation and product ID tracking

### DIFF
--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -60,8 +60,19 @@ AbstractStoreBackend::AbstractStoreBackend(QObject * parent) : QObject(parent)
         });
     });
 
-    connect(this, &AbstractStoreBackend::purchaseFailed, [](int error, int platformCode, const QString& message){
-        qDebug() << "purchaseFailed:" << "error=" << error << "platformCode=" << platformCode << "message=" << message;
+    connect(this, &AbstractStoreBackend::purchaseFailed, 
+            [this](const QString& productId, int error, int platformCode, const QString& message){
+        qDebug() << "purchaseFailed:" << "productId=" << productId 
+                 << "error=" << error << "platformCode=" << platformCode 
+                 << "message=" << message;
+        
+        // Route to the appropriate product
+        AbstractProduct * ap = product(productId);
+        if (ap) {
+            emit ap->purchaseFailed(error, platformCode, message);
+        } else {
+            qWarning() << "Failed to find product for purchase failure:" << productId;
+        }
     });
 
     connect(this, &AbstractStoreBackend::consumePurchaseSucceeded, [this](AbstractTransaction * transaction){

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -38,7 +38,7 @@ public:
     static void productRegistered(JNIEnv * env, jobject object, jstring productJson);
     static void purchaseSucceeded(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchaseRestored(JNIEnv * env, jobject object, jstring purchaseJson);
-    static void purchaseFailed(JNIEnv * env, jobject object, jint billingResponseCode);
+    static void purchaseFailed(JNIEnv * env, jobject object, jstring productId, jint billingResponseCode);
     static void purchaseConsumed(JNIEnv * env, jobject object, jstring purchaseJson);
 
     void startConnection() override;

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -108,10 +108,13 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
             break;
         case AppleAppStoreTransaction::Failed:
             {
+                // Extract product ID from the transaction
+                QString productId = QString::fromNSString(transaction.payment.productIdentifier);
                 int errorCode = transaction.error.code;
                 AbstractStoreBackend::PurchaseError error = AppleAppStoreBackend::mapStoreKitErrorToPurchaseError(errorCode);
                 QString message = AppleAppStoreBackend::getStoreKitErrorMessage(errorCode);
                 QMetaObject::invokeMethod(backend, "purchaseFailed", Qt::AutoConnection, 
+                    Q_ARG(QString, productId),
                     Q_ARG(int, static_cast<int>(error)), 
                     Q_ARG(int, errorCode), 
                     Q_ARG(QString, message));

--- a/src/include/qt6purchasing/abstractproduct.h
+++ b/src/include/qt6purchasing/abstractproduct.h
@@ -95,7 +95,7 @@ signals:
 #endif
 
     void purchaseSucceeded(AbstractTransaction * transaction);
-    void purchaseFailed(AbstractTransaction * transaction);
+    void purchaseFailed(int error, int platformCode, const QString& message);
     void purchaseRestored(AbstractTransaction * transaction);
     void consumePurchaseSucceeded(AbstractTransaction * transaction);
     void consumePurchaseFailed(AbstractTransaction * transaction);

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -69,7 +69,7 @@ signals:
     void productRegistered(AbstractProduct * product);
     void purchaseSucceeded(AbstractTransaction * transaction);
     void purchaseRestored(AbstractTransaction * transaction);
-    void purchaseFailed(int error, int platformCode, const QString& message);
+    void purchaseFailed(const QString& productId, int error, int platformCode, const QString& message);
     void consumePurchaseSucceeded(AbstractTransaction * transaction);
     void consumePurchaseFailed(AbstractTransaction * transaction);
 };

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -191,7 +191,8 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
         constexpr uint32_t SERVICE_UNAVAILABLE = 0x80070005; // E_ACCESSDENIED
         PurchaseError error = PurchaseError::ServiceUnavailable;
         QString message = "Microsoft Store service is unavailable";
-        emit purchaseFailed(static_cast<int>(error), SERVICE_UNAVAILABLE, message);
+        QString productId = product->identifier();
+        emit purchaseFailed(productId, static_cast<int>(error), SERVICE_UNAVAILABLE, message);
         return;
     }
     
@@ -201,7 +202,8 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
         constexpr uint32_t UNKNOWN_ERROR = 0x80004005; // E_FAIL
         PurchaseError error = PurchaseError::UnknownError;
         QString message = "No window handle available for purchase";
-        emit purchaseFailed(static_cast<int>(error), UNKNOWN_ERROR, message);
+        QString productId = product->identifier();
+        emit purchaseFailed(productId, static_cast<int>(error), UNKNOWN_ERROR, message);
         return;
     }
     
@@ -241,7 +243,8 @@ void MicrosoftStoreBackend::onPurchaseComplete(AbstractProduct* product, StorePu
         // Use the real Windows StorePurchaseStatus as platform code
         PurchaseError error = mapWindowsErrorToPurchaseError(static_cast<uint32_t>(status));
         QString message = getWindowsErrorMessage(static_cast<uint32_t>(status));
-        emit purchaseFailed(static_cast<int>(error), static_cast<uint32_t>(status), message);
+        QString productId = product->identifier();
+        emit purchaseFailed(productId, static_cast<int>(error), static_cast<uint32_t>(status), message);
     }
 }
 


### PR DESCRIPTION
Fixes #22.

- Update AbstractStoreBackend::purchaseFailed signal to include productId parameter
- Update AbstractProduct::purchaseFailed signal to use error parameters instead of transaction
- Fix AbstractStoreBackend implementation to properly route failures to individual products
- Android: Add pendingProductId tracking in Java and update JNI callbacks
- iOS: Extract product ID from failed transaction objects
- Windows: Add product ID to all purchaseFailed emissions

This ensures purchase failures are properly routed to the correct Product objects and can be handled in QML via onPurchaseFailed handlers.

🤖 Generated with [Claude Code](https://claude.ai/code)