### PR TITLE
Address implementation gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ int main(int argc, char *argv[])
       }
   }
   ```
+4. **Important**: Call `transaction.finalize()` in **both** `onPurchaseSucceeded` and `onPurchaseRestored` handlers. This ensures:
+   - **Consumables** are properly consumed and can be repurchased
+   - **Durables/Unlockables** complete their transaction acknowledgment
+   - Platform backends handle the finalization appropriately for each product type
 
 
 ## Thread Safety

--- a/README.md
+++ b/README.md
@@ -192,6 +192,41 @@ The library automatically handles consumable fulfillment for Microsoft Store. Wh
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+## iOS Early Initialization (Critical)
+
+On iOS, you **must** call the early initialization in your `main()` function before creating the QML engine:
+
+```cpp
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+#ifdef Q_OS_IOS
+#include "apple/appleappstorebackend.h"
+#endif
+
+int main(int argc, char *argv[])
+{
+    QGuiApplication app(argc, argv);
+    
+#ifdef Q_OS_IOS
+    // Critical: Initialize iOS IAP observer before QML engine creation
+    AppleAppStoreBackend::initializeEarly();
+#endif
+    
+    QQmlApplicationEngine engine;
+    engine.loadFromModule("YourModule", "Main");
+    return app.exec();
+}
+```
+
+**Why this is required:**
+- Apple requires transaction observers to be added at app launch in `application(_:didFinishLaunchingWithOptions:)`
+- Qt/QML creates the Store component later during QML instantiation
+- Without early initialization, transactions that occur during app startup can be lost
+- The early observer queues transactions until the full backend is ready
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 
 
 <!-- USAGE EXAMPLES -->

--- a/src/abstractproduct.cpp
+++ b/src/abstractproduct.cpp
@@ -73,7 +73,6 @@ void AbstractProduct::setStatus(ProductStatus status)
     emit statusChanged();
 }
 
-#ifdef Q_OS_WIN
 void AbstractProduct::setMicrosoftStoreId(const QString &value)
 {
     if (_microsoftStoreId == value)
@@ -82,7 +81,6 @@ void AbstractProduct::setMicrosoftStoreId(const QString &value)
     _microsoftStoreId = value;
     emit microsoftStoreIdChanged();
 }
-#endif
 
 void AbstractProduct::registerInStore()
 {

--- a/src/android/GooglePlayBilling.java
+++ b/src/android/GooglePlayBilling.java
@@ -169,4 +169,9 @@ public class GooglePlayBilling {
             throw new RuntimeException(e);
         }
     }
+
+    public void queryExistingPurchases() {
+        debugMessage("Manual restore purchases triggered - calling queryPurchasesAsync");
+        billingClient.queryPurchasesAsync(SkuType.INAPP, purchasesResponseListener);
+    }
 }

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -154,6 +154,12 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
     );
 }
 
+void GooglePlayStoreBackend::restorePurchases()
+{
+    qDebug() << "Android restorePurchases() called - triggering manual queryPurchasesAsync";
+    _googlePlayBillingJavaClass->callMethod<void>("queryExistingPurchases");
+}
+
 bool GooglePlayStoreBackend::canMakePurchases() const
 {
     // For Android, we can make purchases if we're connected to the billing service

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -25,6 +25,7 @@ GooglePlayStoreBackend::GooglePlayStoreBackend(QObject * parent) : AbstractStore
         {"connectedChangedHelper", "(Z)V", reinterpret_cast<void *>(connectedChangedHelper)},
         {"productRegistered", "(Ljava/lang/String;)V", reinterpret_cast<void *>(productRegistered)},
         {"purchaseSucceeded", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseSucceeded)},
+        {"purchasePending", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchasePending)},
         {"purchaseRestored", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseRestored)},
         {"purchaseFailed", "(Ljava/lang/String;I)V", reinterpret_cast<void *>(purchaseFailed)},
         {"purchaseConsumed", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseConsumed)},
@@ -70,6 +71,7 @@ GooglePlayStoreBackend::~GooglePlayStoreBackend()
         return;
     }
     backend->setConnected(connected);
+    backend->setCanMakePurchases(backend->canMakePurchases());
 }
 
 void GooglePlayStoreBackend::startConnection()
@@ -152,6 +154,12 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
     );
 }
 
+bool GooglePlayStoreBackend::canMakePurchases() const
+{
+    // For Android, we can make purchases if we're connected to the billing service
+    return isConnected();
+}
+
 /*static*/ void GooglePlayStoreBackend::purchaseSucceeded(JNIEnv *env, jobject object, jstring message)
 {
     GooglePlayStoreBackend* backend = GooglePlayStoreBackend::s_currentInstance;
@@ -166,6 +174,36 @@ void GooglePlayStoreBackend::consumePurchase(AbstractTransaction * transaction)
 
     GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(json, backend);
     emit backend->purchaseSucceeded(transaction);
+}
+
+/*static*/ void GooglePlayStoreBackend::purchasePending(JNIEnv *env, jobject object, jstring message)
+{
+    GooglePlayStoreBackend* backend = GooglePlayStoreBackend::s_currentInstance;
+    if (!backend) {
+        qCritical() << "Google Play pending purchase callback received but backend instance is null";
+        return;
+    }
+
+    const char* jsonCStr = env->GetStringUTFChars(message, nullptr);
+    QJsonObject json = QJsonDocument::fromJson(jsonCStr).object();
+    env->ReleaseStringUTFChars(message, jsonCStr);
+
+    qDebug() << "Android purchase pending for product:" << json.value("productId").toString();
+    
+    // For pending purchases, we need to create a transaction but not grant content yet
+    // The purchase will transition to PURCHASED later and we'll get purchaseSucceeded callback
+    GooglePlayStoreTransaction * transaction = new GooglePlayStoreTransaction(json, backend);
+    
+    // Find the product and emit a pending signal
+    QString productId = json.value("productId").toString();
+    AbstractProduct * product = backend->product(productId);
+    if (product) {
+        qDebug() << "Emitting purchase pending for product:" << productId;
+        emit backend->purchasePending(transaction);
+    } else {
+        qWarning() << "Could not find product for pending purchase:" << productId;
+        transaction->deleteLater();
+    }
 }
 
 /*static*/ void GooglePlayStoreBackend::purchaseRestored(JNIEnv *env, jobject object, jstring message)

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -37,6 +37,7 @@ public:
     static void connectedChangedHelper(JNIEnv * env, jobject object, jboolean connected);
     static void productRegistered(JNIEnv * env, jobject object, jstring productJson);
     static void purchaseSucceeded(JNIEnv * env, jobject object, jstring purchaseJson);
+    static void purchasePending(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchaseRestored(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchaseFailed(JNIEnv * env, jobject object, jstring productId, jint billingResponseCode);
     static void purchaseConsumed(JNIEnv * env, jobject object, jstring purchaseJson);
@@ -45,6 +46,7 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    bool canMakePurchases() const override;
 
 private:
     static PurchaseError mapBillingResponseToPurchaseError(int billingResponseCode);

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -46,6 +46,7 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    void restorePurchases() override;
     bool canMakePurchases() const override;
 
 private:

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -25,8 +25,6 @@ public:
     static AppleAppStoreBackend * s_currentInstance;
 
 private:
-    static PurchaseError mapStoreKitErrorToPurchaseError(int errorCode);
-    static QString getStoreKitErrorMessage(int errorCode);
     
     InAppPurchaseManager * _iapManager = nullptr;
 

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -18,6 +18,7 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    void restorePurchases() override;
     bool canMakePurchases() const override;
 
     static void initializeEarly();

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -18,6 +18,9 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    bool canMakePurchases() const override;
+
+    static void initializeEarly();
 
     static AppleAppStoreBackend * s_currentInstance;
 

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -280,6 +280,12 @@ void AppleAppStoreBackend::consumePurchase(AbstractTransaction * transaction)
     emit consumePurchaseSucceeded(transaction);
 }
 
+void AppleAppStoreBackend::restorePurchases()
+{
+    qDebug() << "iOS restorePurchases() called - triggering SKPaymentQueue.restoreCompletedTransactions";
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+}
+
 bool AppleAppStoreBackend::canMakePurchases() const
 {
     return [SKPaymentQueue canMakePayments];

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -226,7 +226,7 @@ AppleAppStoreBackend* AppleAppStoreBackend::s_currentInstance = nullptr;
             QMetaObject::invokeMethod(backend, "purchaseRestored", Qt::AutoConnection, Q_ARG(AbstractTransaction*, ta));
             break;
         case AppleAppStoreTransaction::Deferred:
-            //unhandled
+            QMetaObject::invokeMethod(backend, "purchasePending", Qt::AutoConnection, Q_ARG(AbstractTransaction*, ta));
             break;
         }
     }

--- a/src/include/qt6purchasing/abstractproduct.h
+++ b/src/include/qt6purchasing/abstractproduct.h
@@ -19,9 +19,7 @@ class AbstractProduct : public QObject
     // writable properties
     Q_PROPERTY(QString identifier READ identifier WRITE setIdentifier NOTIFY identifierChanged REQUIRED)
     Q_PROPERTY(ProductType type READ productType WRITE setProductType NOTIFY productTypeChanged REQUIRED)
-#ifdef Q_OS_WIN
     Q_PROPERTY(QString microsoftStoreId READ microsoftStoreId WRITE setMicrosoftStoreId NOTIFY microsoftStoreIdChanged)
-#endif
     // read only properties
     Q_PROPERTY(ProductStatus status READ status NOTIFY statusChanged)
     Q_PROPERTY(QString description READ description NOTIFY descriptionChanged)
@@ -49,9 +47,7 @@ public:
     QString price() const { return _price; }
     ProductType productType() const { return _productType; }
     QString title() const { return _title; }
-#ifdef Q_OS_WIN
     QString microsoftStoreId() const { return _microsoftStoreId; }
-#endif
 
     void setIdentifier(const QString &value);
     void setProductType(ProductType type);
@@ -59,9 +55,7 @@ public:
     void setDescription(QString value);
     void setPrice(const QString &value);
     void setTitle(const QString &value);
-#ifdef Q_OS_WIN
     void setMicrosoftStoreId(const QString &value);
-#endif
 
     void registerInStore();
 
@@ -76,9 +70,7 @@ protected:
     QString _price;
     ProductType _productType;
     QString _title;
-#ifdef Q_OS_WIN
     QString _microsoftStoreId;
-#endif
 
 private:
     AbstractStoreBackend* findStoreBackend() const;
@@ -90,9 +82,7 @@ signals:
     void priceChanged();
     void productTypeChanged();
     void titleChanged();
-#ifdef Q_OS_WIN
     void microsoftStoreIdChanged();
-#endif
 
     void purchaseSucceeded(AbstractTransaction * transaction);
     void purchasePending(AbstractTransaction * transaction);

--- a/src/include/qt6purchasing/abstractproduct.h
+++ b/src/include/qt6purchasing/abstractproduct.h
@@ -95,6 +95,7 @@ signals:
 #endif
 
     void purchaseSucceeded(AbstractTransaction * transaction);
+    void purchasePending(AbstractTransaction * transaction);
     void purchaseFailed(int error, int platformCode, const QString& message);
     void purchaseRestored(AbstractTransaction * transaction);
     void consumePurchaseSucceeded(AbstractTransaction * transaction);

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -51,6 +51,8 @@ public:
     virtual void purchaseProduct(AbstractProduct * product) = 0;
     virtual void consumePurchase(AbstractTransaction * transaction) = 0;
 
+    Q_INVOKABLE virtual void restorePurchases() = 0;
+
 protected:
     explicit AbstractStoreBackend(QObject * parent = nullptr);
     QList<AbstractProduct *> _products;

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -37,12 +37,14 @@ public:
     Q_PROPERTY(QQmlListProperty<AbstractProduct> productsQml READ productsQml NOTIFY productsChanged)
     Q_CLASSINFO("DefaultProperty", "productsQml")
     Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged FINAL)
+    Q_PROPERTY(bool canMakePurchases READ canMakePurchases NOTIFY canMakePurchasesChanged FINAL)
 
 public:
     QQmlListProperty<AbstractProduct> productsQml();
     QList<AbstractProduct *> products() { return _products; }
     AbstractProduct * product(const QString &identifier);
     bool isConnected() const { return _connected; }
+    virtual bool canMakePurchases() const = 0;
 
     virtual void startConnection() = 0;
     virtual void registerProduct(AbstractProduct * product) = 0;
@@ -53,8 +55,10 @@ protected:
     explicit AbstractStoreBackend(QObject * parent = nullptr);
     QList<AbstractProduct *> _products;
     bool _connected = false;
+    bool _canMakePurchases = false;
 
     void setConnected(bool connected);
+    void setCanMakePurchases(bool canMakePurchases);
 
 private:
     static void appendProduct(QQmlListProperty<AbstractProduct> *list, AbstractProduct *product);
@@ -65,9 +69,11 @@ private:
 signals:
     void productsChanged();
     void connectedChanged();
+    void canMakePurchasesChanged();
 
     void productRegistered(AbstractProduct * product);
     void purchaseSucceeded(AbstractTransaction * transaction);
+    void purchasePending(AbstractTransaction * transaction);
     void purchaseRestored(AbstractTransaction * transaction);
     void purchaseFailed(const QString& productId, int error, int platformCode, const QString& message);
     void consumePurchaseSucceeded(AbstractTransaction * transaction);

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -83,7 +83,7 @@ void MicrosoftStoreBackend::queryAllProducts()
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreAllProductsWorker::performQuery);
-    connect(worker, &StoreAllProductsWorker::queryComplete, this, &MicrosoftStoreBackend::onAllProductsQueried);
+    connect(worker, &StoreAllProductsWorker::queryComplete, this, &MicrosoftStoreBackend::onAllProductsQueried, Qt::QueuedConnection);
     connect(worker, &StoreAllProductsWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreAllProductsWorker::finished, worker, &StoreAllProductsWorker::deleteLater);
@@ -136,7 +136,7 @@ void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
     connect(worker, &StoreProductQueryWorker::queryComplete, 
             [this, product](bool success, const QVariantMap& productData) {
                 this->onProductQueried(product, success, productData);
-            });
+            }, Qt::QueuedConnection);
     connect(worker, &StoreProductQueryWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreProductQueryWorker::finished, worker, &StoreProductQueryWorker::deleteLater);
@@ -231,7 +231,7 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
     connect(worker, &StorePurchaseWorker::purchaseComplete, 
             [this, product](StorePurchaseStatus status) {
                 this->onPurchaseComplete(product, status);
-            });
+            }, Qt::QueuedConnection);
     connect(worker, &StorePurchaseWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StorePurchaseWorker::finished, worker, &StorePurchaseWorker::deleteLater);
@@ -326,7 +326,7 @@ void MicrosoftStoreBackend::consumePurchase(AbstractTransaction * transaction)
                 
                 // Safe cleanup now that signals are emitted
                 transaction->destroy();
-            });
+            }, Qt::QueuedConnection);
     connect(worker, &StoreConsumableFulfillmentWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreConsumableFulfillmentWorker::finished, worker, &StoreConsumableFulfillmentWorker::deleteLater);
@@ -353,7 +353,7 @@ void MicrosoftStoreBackend::restorePurchases()
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreRestoreWorker::performRestore);
-    connect(worker, &StoreRestoreWorker::restoreComplete, this, &MicrosoftStoreBackend::onRestoreComplete);
+    connect(worker, &StoreRestoreWorker::restoreComplete, this, &MicrosoftStoreBackend::onRestoreComplete, Qt::QueuedConnection);
     connect(worker, &StoreRestoreWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreRestoreWorker::finished, worker, &StoreRestoreWorker::deleteLater);

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -133,7 +133,7 @@ void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreProductQueryWorker::performQuery);
-    connect(worker, &StoreProductQueryWorker::queryComplete, 
+    connect(worker, &StoreProductQueryWorker::queryComplete, this,
             [this, product](bool success, const QVariantMap& productData) {
                 this->onProductQueried(product, success, productData);
             }, Qt::QueuedConnection);
@@ -228,7 +228,7 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StorePurchaseWorker::performPurchase);
-    connect(worker, &StorePurchaseWorker::purchaseComplete, 
+    connect(worker, &StorePurchaseWorker::purchaseComplete, this,
             [this, product](StorePurchaseStatus status) {
                 this->onPurchaseComplete(product, status);
             }, Qt::QueuedConnection);
@@ -313,7 +313,7 @@ void MicrosoftStoreBackend::consumePurchase(AbstractTransaction * transaction)
     // Capture transaction data by value for logging
     QString orderId = transaction->orderId();
     QString productId = transaction->productId();
-    connect(worker, &StoreConsumableFulfillmentWorker::fulfillmentComplete, 
+    connect(worker, &StoreConsumableFulfillmentWorker::fulfillmentComplete, this,
             [this, transaction, orderId, productId](bool success, const QString& result) {
                 this->onConsumableFulfillmentComplete(orderId, productId, success, result);
                 

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -62,6 +62,7 @@ void MicrosoftStoreBackend::startConnection()
     
     // Simple connection check - we'll initialize StoreContext in workers
     setConnected(true);
+    setCanMakePurchases(canMakePurchases());
     qDebug() << "Microsoft Store connection established";
     
     // Query all products on startup
@@ -383,6 +384,12 @@ void MicrosoftStoreBackend::onConsumableFulfillmentComplete(const QString& order
     }
     
     // Note: consumePurchase success/failure signals are now emitted in the lambda to ensure transaction validity
+}
+
+bool MicrosoftStoreBackend::canMakePurchases() const
+{
+    // For Windows, we can make purchases if we're connected to the store
+    return isConnected();
 }
 
 AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapWindowsErrorToPurchaseError(uint32_t statusCode)

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -238,6 +238,7 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
 
 void MicrosoftStoreBackend::onPurchaseComplete(AbstractProduct* product, StorePurchaseStatus status)
 {
+    qDebug() << "onPurchaseComplete: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
     if (status == StorePurchaseStatus::Succeeded) {
         // Create minimal transaction for success
         QString orderId = QString("ms_%1_%2").arg(product->identifier()).arg(QDateTime::currentMSecsSinceEpoch());
@@ -332,6 +333,8 @@ void MicrosoftStoreBackend::consumePurchase(AbstractTransaction * transaction)
 
 void MicrosoftStoreBackend::restorePurchases()
 {
+    qDebug() << "restorePurchases() called, products count:" << products().size();
+    
     if (!isConnected()) {
         qWarning() << "Cannot restore purchases - store not connected";
         return;
@@ -357,6 +360,7 @@ void MicrosoftStoreBackend::restorePurchases()
 
 void MicrosoftStoreBackend::onRestoreComplete(const QList<QVariantMap> &restoredProducts)
 {
+    qDebug() << "onRestoreComplete: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
     qDebug() << "Restore complete, found" << restoredProducts.size() << "owned products";
     
     for (const auto& productData : restoredProducts) {

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -79,7 +79,7 @@ void MicrosoftStoreBackend::queryAllProducts()
     }
     
     auto* worker = new StoreAllProductsWorker(_hwnd);
-    auto* thread = new QThread(nullptr);
+    auto* thread = new QThread(this);
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreAllProductsWorker::performQuery);
@@ -129,7 +129,7 @@ void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
 #endif
     
     auto* worker = new StoreProductQueryWorker(productId, _hwnd);
-    auto* thread = new QThread(nullptr);
+    auto* thread = new QThread(this);
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreProductQueryWorker::performQuery);
@@ -224,7 +224,7 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
 #endif
     
     auto* worker = new StorePurchaseWorker(productId, _hwnd);
-    auto* thread = new QThread(nullptr);
+    auto* thread = new QThread(this);
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StorePurchaseWorker::performPurchase);
@@ -303,7 +303,7 @@ void MicrosoftStoreBackend::consumePurchase(AbstractTransaction * transaction)
     
     // Create fulfillment worker
     auto* worker = new StoreConsumableFulfillmentWorker(storeId, 1, _hwnd); // quantity = 1
-    auto* thread = new QThread(nullptr);
+    auto* thread = new QThread(this);
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreConsumableFulfillmentWorker::performFulfillment);
@@ -349,7 +349,7 @@ void MicrosoftStoreBackend::restorePurchases()
     }
     
     auto* worker = new StoreRestoreWorker(_hwnd);
-    auto* thread = new QThread(nullptr);
+    auto* thread = new QThread(this);
     
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreRestoreWorker::performRestore);

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -67,6 +67,9 @@ void MicrosoftStoreBackend::startConnection()
     
     // Query all products on startup
     queryAllProducts();
+    
+    // Automatically restore existing purchases on startup
+    restorePurchases();
 }
 
 void MicrosoftStoreBackend::queryAllProducts()

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -68,8 +68,7 @@ void MicrosoftStoreBackend::startConnection()
     // Query all products on startup
     queryAllProducts();
     
-    // Automatically restore existing purchases on startup
-    restorePurchases();
+    // Note: restorePurchases() will be called after products are queried
 }
 
 void MicrosoftStoreBackend::queryAllProducts()
@@ -99,6 +98,10 @@ void MicrosoftStoreBackend::onAllProductsQueried(const QList<QVariantMap> &produ
         qDebug() << "Available product:" << product["productId"].toString()
                  << "Title:" << product["title"].toString();
     }
+    
+    // Now that products are available, restore existing purchases
+    qDebug() << "Products queried, now calling restorePurchases()";
+    restorePurchases();
 }
 
 void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)

--- a/src/windows/microsoftstorebackend.h
+++ b/src/windows/microsoftstorebackend.h
@@ -21,6 +21,7 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    bool canMakePurchases() const override;
     void restorePurchases();
 
     static MicrosoftStoreBackend * s_currentInstance;

--- a/src/windows/microsoftstorebackend.h
+++ b/src/windows/microsoftstorebackend.h
@@ -21,8 +21,8 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(AbstractTransaction * transaction) override;
+    void restorePurchases() override;
     bool canMakePurchases() const override;
-    void restorePurchases();
 
     static MicrosoftStoreBackend * s_currentInstance;
 


### PR DESCRIPTION
This pull request focuses on closing functional and structural gaps in the current implementation. Primarily this includes edge cases outside the normal purchase flow, such as:
- pending transactions (e.g. transactions that completed on the remote store but didn't get handled within the app, for example due to a crash);
- deferred transactions (e.g. where parental 'Ask to buy' gets triggered);
- automatic restore purchases on start-up;
- manual restore purchases on demand.

README has been updated with a number of edge cases, including per-platform details. For example, on `purchaseRestored`, it's important the developer finalizes restored purchases, just like a successful new purchase — this is particularly important for consumables because any consumable that shows up as 'already purchased' means that the finalize (consume) step hadn't been done and this would block further purchases on some platforms.

There are also some code fixes, in particular:
- handling of lambdas, such that threads are correctly parented and don't leave a dangling thread on app quit;
- support for early initialization on iOS, with README notes for steps the developer needs to take.