### PR TITLE
Restore purchases success and failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,44 @@ Store {
    - **Durables/Unlockables** complete their transaction acknowledgment
    - Platform backends handle the finalization appropriately for each product type
 
+## Monitoring Restore Progress and Errors
+
+The Store component provides signals to monitor restore operations and handle errors:
+
+```qml
+Qt6Purchasing.Store {
+    id: iapStore
+
+    onRestorePurchasesSucceeded: (count) => {
+        console.log("Restore completed successfully. Count:", count)
+        if (count === 0) {
+            console.log("No previous purchases found")
+        } else {
+            console.log(count + " purchase(s) restored")
+        }
+    }
+
+    onRestorePurchasesFailed: (error, platformCode, message) => {
+        console.error("Restore failed:", message)
+        console.error("Error type:", error, "Platform code:", platformCode)
+    }
+
+    // Individual restored purchases still arrive via Product.onPurchaseRestored
+    // Handle them in your Product's onPurchaseRestored handler
+}
+```
+
+**Important notes:**
+- `restorePurchasesSucceeded(count)` is emitted when restore completes, even if count is 0
+- Individual restored purchases are delivered via `Product.onPurchaseRestored` before the success signal
+- `isRestoringPurchases` property tracks restore operation state
+- The Store automatically prevents concurrent restore operations
+
+**Platform-specific restore behaviors:**
+- **iOS**: Calls `SKPaymentQueue.restoreCompletedTransactions()`. Reports success when restore completes, even if 0 purchases found.
+- **Android**: Calls `queryPurchasesAsync()`. Failure indicates billing service issue (network, disconnected service, etc.).
+- **Windows**: Calls `GetUserCollectionAsync()`. Queries user's product collection from Microsoft Store.
+
 
 ## Edge Cases and Platform-Specific Behaviors
 
@@ -468,16 +506,27 @@ Understanding these scenarios is critical for robust production deployment:
 **Developer action**: Handle `onPurchaseFailed` with service-related errors gracefully. Show user-friendly "store temporarily unavailable" messages. Implement retry mechanisms with reasonable delays.
 
 ### 7. Restore Purchase Edge Cases
-**What happens**: Restore purchases doesn't return all expected results due to account or platform limitations.
+**What happens**: Restore purchases doesn't return all expected results due to account, platform, or network limitations.
 
 **Platform notes**:
-- **iOS**: Cross-device restore requires same Apple ID and account mismatches prevent some restores.
-- **Android**: Restore works via Google account and purchase history is tied to specific Google account.
-- **Windows**: Microsoft account-based restore with purchases tied to specific Microsoft account and device family.
+- **iOS**: Cross-device restore requires same Apple ID and account mismatches prevent some restores. Network failures during restore trigger `restorePurchasesFailed`.
+- **Android**: Restore works via Google account and purchase history is tied to specific Google account. Billing service disconnection or network issues cause restore failures.
+- **Windows**: Microsoft account-based restore with purchases tied to specific Microsoft account and device family. Store API errors are reported via `restorePurchasesFailed`.
 
-**Library behaviour**: Calls platform restore APIs and delivers all available restored purchases via `purchaseRestored` signals. Logs warnings for purchases that cannot be mapped to registered products.
+**Library behaviour**:
+- Calls platform restore APIs and delivers all available restored purchases via `purchaseRestored` signals
+- Emits `restorePurchasesSucceeded(count)` when restore completes successfully (count may be 0)
+- Emits `restorePurchasesFailed(error, platformCode, message)` on errors (network, authentication, service unavailable, etc.)
+- Logs warnings for purchases that cannot be mapped to registered products
+- Automatically prevents concurrent restore operations via `isRestoringPurchases` property
 
-**Developer action**: Handle partial restore scenarios gracefully. Inform users about account requirements for restore (same Apple ID, Google account, Microsoft account). Don't assume restore will return all historical purchases.
+**Developer action**:
+- Handle both `onRestorePurchasesSucceeded` and `onRestorePurchasesFailed` signals
+- Treat 0 count as valid success case (no purchases to restore)
+- Show user-friendly error messages for restore failures
+- Inform users about account requirements for restore (same Apple ID, Google account, Microsoft account)
+- Don't assume restore will return all historical purchases
+- Check `isRestoringPurchases` property if you need to prevent UI actions during restore
 
 ### 8. Development vs Production Environment Differences
 **What happens**: Different behavior between testing and production deployments.

--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ Store {
 - Transaction signals emitted before products exist cause "Failed to map purchase to product" errors
 
 **Platform-Specific Behavior:**
-- **iOS**: Queues early transactions, processes when enabled
-- **Android**: Queues Google Play callbacks, processes when enabled
-- **Windows**: Queues Store completion events, processes when enabled
+- **iOS**: Queues early transactions, processes when enabled. Does not automatically restore purchases on startup.
+- **Android**: Queues Google Play callbacks, processes when enabled. Automatically queries purchases on connection (individual `purchaseRestored` signals are queued, but `restorePurchasesSucceeded`/`restorePurchasesFailed` signals may fire before processing is enabled).
+- **Windows**: Queues Store completion events, processes when enabled. Automatically restores purchases after product query completes (all signals are queued until processing is enabled).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -419,14 +419,21 @@ Qt6Purchasing.Store {
 
 **Important notes:**
 - `restorePurchasesSucceeded(count)` is emitted when restore completes, even if count is 0
-- Individual restored purchases are delivered via `Product.onPurchaseRestored` before the success signal
+- Individual restored purchases are delivered via `Product.onPurchaseRestored`
 - `isRestoringPurchases` property tracks restore operation state
 - The Store automatically prevents concurrent restore operations
 
-**Platform-specific restore behaviors:**
-- **iOS**: Calls `SKPaymentQueue.restoreCompletedTransactions()`. Reports success when restore completes, even if 0 purchases found.
-- **Android**: Calls `queryPurchasesAsync()`. Failure indicates billing service issue (network, disconnected service, etc.).
-- **Windows**: Calls `GetUserCollectionAsync()`. Queries user's product collection from Microsoft Store.
+### Platform-specific restore behaviors
+
+**Automatic vs Manual Restore:**
+- **iOS**: Manual only. Call `store.restorePurchases()` when needed (e.g., from a "Restore Purchases" button). Best practice: wait until after `enableProcessing()` has been called to ensure proper signal delivery.
+- **Android**: Automatic on connection. Also supports manual `store.restorePurchases()` calls. Note that automatic restore on startup may emit `restorePurchasesSucceeded`/`restorePurchasesFailed` before processing is enabled, though individual `purchaseRestored` signals are queued properly.
+- **Windows**: Automatic after product query. Also supports manual `store.restorePurchases()` calls. All restore-related signals are queued until processing is enabled.
+
+**Platform APIs:**
+- **iOS**: `SKPaymentQueue.restoreCompletedTransactions()`. Reports success when restore completes, even if 0 purchases found.
+- **Android**: `queryPurchasesAsync()` for INAPP purchases. Failure indicates billing service issue (network, disconnected service, etc.).
+- **Windows**: `GetUserCollectionAsync()`. Queries user's product collection from Microsoft Store.
 
 
 ## Edge Cases and Platform-Specific Behaviors
@@ -509,12 +516,15 @@ Understanding these scenarios is critical for robust production deployment:
 **What happens**: Restore purchases doesn't return all expected results due to account, platform, or network limitations.
 
 **Platform notes**:
-- **iOS**: Cross-device restore requires same Apple ID and account mismatches prevent some restores. Network failures during restore trigger `restorePurchasesFailed`.
-- **Android**: Restore works via Google account and purchase history is tied to specific Google account. Billing service disconnection or network issues cause restore failures.
-- **Windows**: Microsoft account-based restore with purchases tied to specific Microsoft account and device family. Store API errors are reported via `restorePurchasesFailed`.
+- **iOS**: Cross-device restore requires same Apple ID and account mismatches prevent some restores. Network failures during restore trigger `restorePurchasesFailed`. Restore is manual only - not called automatically on startup.
+- **Android**: Restore works via Google account and purchase history is tied to specific Google account. Billing service disconnection or network issues cause restore failures. Automatically queries purchases when billing service connects.
+- **Windows**: Microsoft account-based restore with purchases tied to specific Microsoft account and device family. Store API errors are reported via `restorePurchasesFailed`. Automatically restores purchases after initial product query.
 
 **Library behaviour**:
-- Calls platform restore APIs and delivers all available restored purchases via `purchaseRestored` signals
+- **Windows**: Automatically calls restore after product query completes. All restore signals (including `restorePurchasesSucceeded`/`restorePurchasesFailed`) are queued until `enableProcessing()` is called.
+- **Android**: Automatically queries purchases on billing service connection. Individual `purchaseRestored` signals are queued, but `restorePurchasesSucceeded`/`restorePurchasesFailed` may be emitted before `enableProcessing()`.
+- **iOS**: Does not automatically restore. Call `store.restorePurchases()` manually (best practice: after `enableProcessing()` has been called).
+- All platforms deliver available restored purchases via `purchaseRestored` signals
 - Emits `restorePurchasesSucceeded(count)` when restore completes successfully (count may be 0)
 - Emits `restorePurchasesFailed(error, platformCode, message)` on errors (network, authentication, service unavailable, etc.)
 - Logs warnings for purchases that cannot be mapped to registered products
@@ -523,6 +533,8 @@ Understanding these scenarios is critical for robust production deployment:
 **Developer action**:
 - Handle both `onRestorePurchasesSucceeded` and `onRestorePurchasesFailed` signals
 - Treat 0 count as valid success case (no purchases to restore)
+- For Android: Be aware that completion signals may arrive before `enableProcessing()`, though individual restores will be queued
+- For iOS: Call `store.restorePurchases()` after `enableProcessing()` for best results
 - Show user-friendly error messages for restore failures
 - Inform users about account requirements for restore (same Apple ID, Google account, Microsoft account)
 - Don't assume restore will return all historical purchases

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -113,6 +113,16 @@ AbstractProduct * AbstractStoreBackend::product(const QString &identifier)
     return nullptr;
 }
 
+void AbstractStoreBackend::restorePurchases()
+{
+    if (isRestoringPurchases()) {
+        emit restorePurchasesFailed(static_cast<int>(PurchaseError::Busy), 0, "");
+        return;
+    }
+
+    setIsRestoringPurchases(true);
+}
+
 void AbstractStoreBackend::finalize(Transaction transaction)
 {
     qDebug() << "Store: Finalizing transaction" << transaction.orderId;

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -133,6 +133,16 @@ void AbstractStoreBackend::setCanMakePurchases(bool canMakePurchases)
     qDebug() << "Store canMakePurchases status changed to" << (_canMakePurchases ? "enabled" : "disabled");
 }
 
+void AbstractStoreBackend::setIsRestoringPurchases(bool restoring)
+{
+    if (_isRestoringPurchases == restoring)
+        return;
+
+    _isRestoringPurchases = restoring;
+    emit isRestoringPurchasesChanged();
+    qDebug() << "Store isRestoringPurchases status changed to" << (_isRestoringPurchases ? "true" : "false");
+}
+
 void AbstractStoreBackend::finalize(Transaction transaction)
 {
     qDebug() << "Store: Finalizing transaction" << transaction.orderId;

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -134,6 +134,7 @@ void AbstractStoreBackend::restorePurchases()
     }
 
     setIsRestoringPurchases(true);
+    restorePurchasesImpl();
 }
 
 void AbstractStoreBackend::finalize(Transaction transaction)

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -93,6 +93,19 @@ AbstractStoreBackend::AbstractStoreBackend(QObject * parent) : QObject(parent)
             qCritical() << "Failed to map failed consumption to a product!";
         }
     });
+
+    connect(this, &AbstractStoreBackend::restorePurchasesSucceeded, this, [this](int count){
+        qDebug() << "restorePurchasesSucceeded: count=" << count;
+        setIsRestoringPurchases(false);
+    });
+
+    connect(this, &AbstractStoreBackend::restorePurchasesFailed, this,
+            [this](int error, int platformCode, const QString& message){
+        qDebug() << "restorePurchasesFailed:" << "error=" << error
+                 << "platformCode=" << platformCode
+                 << "message=" << message;
+        setIsRestoringPurchases(false);
+    });
 }
 
 QQmlListProperty<AbstractProduct> AbstractStoreBackend::productsQml()

--- a/src/abstractstorebackend.cpp
+++ b/src/abstractstorebackend.cpp
@@ -113,6 +113,18 @@ AbstractProduct * AbstractStoreBackend::product(const QString &identifier)
     return nullptr;
 }
 
+void AbstractStoreBackend::finalize(Transaction transaction)
+{
+    qDebug() << "Store: Finalizing transaction" << transaction.orderId;
+    consumePurchase(transaction);
+}
+
+void AbstractStoreBackend::enableProcessing() {
+    if (_processingEnabled) return;
+    _processingEnabled = true;
+    emit processingEnabledChanged();
+}
+
 void AbstractStoreBackend::setConnected(bool connected)
 {
     if (_connected == connected)
@@ -141,18 +153,6 @@ void AbstractStoreBackend::setIsRestoringPurchases(bool restoring)
     _isRestoringPurchases = restoring;
     emit isRestoringPurchasesChanged();
     qDebug() << "Store isRestoringPurchases status changed to" << (_isRestoringPurchases ? "true" : "false");
-}
-
-void AbstractStoreBackend::finalize(Transaction transaction)
-{
-    qDebug() << "Store: Finalizing transaction" << transaction.orderId;
-    consumePurchase(transaction);
-}
-
-void AbstractStoreBackend::enableProcessing() {
-    if (_processingEnabled) return;
-    _processingEnabled = true;
-    emit processingEnabledChanged();
 }
 
 // Static QQmlListProperty accessors

--- a/src/android/GooglePlayBilling.java
+++ b/src/android/GooglePlayBilling.java
@@ -25,6 +25,8 @@ public class GooglePlayBilling {
     private static native void purchaseRestored(String purchaseJson);
     private static native void purchaseFailed(String productId, int billingResponseCode);
     private static native void purchaseConsumed(String purchaseJson);
+    private static native void restorePurchasesSucceeded(int count);
+    private static native void restorePurchasesFailed(int billingResponseCode);
 
     private Context context;
     private PurchasesUpdatedListener purchasesUpdatedListener;
@@ -67,10 +69,18 @@ public class GooglePlayBilling {
         purchasesResponseListener = new PurchasesResponseListener() {
             @Override
             public void onQueryPurchasesResponse(BillingResult billingResult, List<Purchase> purchases) {
-                if (!purchases.isEmpty()) {
-                    for (Purchase purchase : purchases) {
-                        purchaseRestored(purchase.getOriginalJson());
+                if (billingResult.getResponseCode() == BillingResponseCode.OK) {
+                    int count = 0;
+                    if (purchases != null && !purchases.isEmpty()) {
+                        for (Purchase purchase : purchases) {
+                            purchaseRestored(purchase.getOriginalJson());
+                            count++;
+                        }
                     }
+                    restorePurchasesSucceeded(count);
+                } else {
+                    debugMessage("Restore purchases failed with response code: " + billingResult.getResponseCode());
+                    restorePurchasesFailed(billingResult.getResponseCode());
                 }
             }
         };

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -47,6 +47,8 @@ GooglePlayStoreBackend::GooglePlayStoreBackend(QObject * parent) : AbstractStore
         {"purchaseRestored", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseRestored)},
         {"purchaseFailed", "(Ljava/lang/String;I)V", reinterpret_cast<void *>(purchaseFailed)},
         {"purchaseConsumed", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseConsumed)},
+        {"restorePurchasesSucceeded", "(I)V", reinterpret_cast<void *>(restorePurchasesSucceeded)},
+        {"restorePurchasesFailed", "(I)V", reinterpret_cast<void *>(restorePurchasesFailed)},
     };
     QJniEnvironment env;
     jclass objectClass = env->GetObjectClass(_googlePlayBillingJavaClass->object<jobject>());
@@ -174,9 +176,9 @@ void GooglePlayStoreBackend::consumePurchase(Transaction transaction)
     );
 }
 
-void GooglePlayStoreBackend::restorePurchases()
+void GooglePlayStoreBackend::restorePurchasesImpl()
 {
-    qDebug() << "Android restorePurchases() called - triggering manual queryPurchasesAsync";
+    qDebug() << "Android restorePurchasesImpl() called - triggering manual queryPurchasesAsync";
     _googlePlayBillingJavaClass->callMethod<void>("queryExistingPurchases");
 }
 
@@ -292,6 +294,34 @@ bool GooglePlayStoreBackend::canMakePurchases() const
 
     auto transaction = transactionFromJson(json);
     emit backend->consumePurchaseSucceeded(transaction);
+}
+
+/*static*/ void GooglePlayStoreBackend::restorePurchasesSucceeded(JNIEnv *env, jobject object, jint count)
+{
+    GooglePlayStoreBackend * backend = GooglePlayStoreBackend::s_currentInstance;
+    if (!backend) {
+        qWarning() << "Android: restorePurchasesSucceeded received but backend instance is null";
+        return;
+    }
+
+    qDebug() << "Android: Restore purchases completed successfully. Count:" << count;
+    emit backend->restorePurchasesSucceeded(count);
+}
+
+/*static*/ void GooglePlayStoreBackend::restorePurchasesFailed(JNIEnv *env, jobject object, jint billingResponseCode)
+{
+    GooglePlayStoreBackend * backend = GooglePlayStoreBackend::s_currentInstance;
+    if (!backend) {
+        qWarning() << "Android: restorePurchasesFailed received but backend instance is null";
+        return;
+    }
+
+    qDebug() << "Android: Restore purchases failed with billing response code:" << billingResponseCode;
+
+    PurchaseError mappedError = mapBillingResponseToPurchaseError(billingResponseCode);
+    QString message = getBillingResponseMessage(billingResponseCode);
+
+    emit backend->restorePurchasesFailed(static_cast<int>(mappedError), billingResponseCode, message);
 }
 
 /*static*/ AbstractStoreBackend::PurchaseError GooglePlayStoreBackend::mapBillingResponseToPurchaseError(int billingResponseCode)

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -41,16 +41,20 @@ public:
     static void purchaseRestored(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchaseFailed(JNIEnv * env, jobject object, jstring productId, jint billingResponseCode);
     static void purchaseConsumed(JNIEnv * env, jobject object, jstring purchaseJson);
+    static void restorePurchasesSucceeded(JNIEnv * env, jobject object, jint count);
+    static void restorePurchasesFailed(JNIEnv * env, jobject object, jint billingResponseCode);
 
     void startConnection() override;
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(Transaction transaction) override;
-    void restorePurchases() override;
     bool canMakePurchases() const override;
 
     // Transaction processing control
     void enableProcessing() override;
+
+protected:
+    void restorePurchasesImpl() override;
 
 private:
     void processQueuedTransactions();

--- a/src/apple/appleappstorebackend.h
+++ b/src/apple/appleappstorebackend.h
@@ -18,7 +18,6 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(Transaction transaction) override;
-    void restorePurchases() override;
     bool canMakePurchases() const override;
 
     // Transaction processing control
@@ -31,10 +30,15 @@ public:
 
     // Internal access for EarlyTransactionObserver
     InAppPurchaseManager * iapManager() const { return _iapManager; }
+    int restoredPurchasesCount() const { return _restoredPurchasesCount; }
+
+protected:
+    void restorePurchasesImpl() override;
 
 private:
-    
+
     InAppPurchaseManager * _iapManager = nullptr;
+    int _restoredPurchasesCount = 0;
 
 };
 

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -41,6 +41,7 @@ static AbstractStoreBackend::PurchaseError mapStoreKitErrorToPurchaseError(int e
             return AbstractStoreBackend::PurchaseError::NotAllowed;
         case SKErrorPaymentInvalid:
         case SKErrorClientInvalid: // See https://stackoverflow.com/a/10975530/457584
+        case SKErrorInvalidSignature: // Cryptographic signature against promo code is invalid
             return AbstractStoreBackend::PurchaseError::PaymentInvalid;
         case SKErrorStoreProductNotAvailable:
             return AbstractStoreBackend::PurchaseError::ItemUnavailable;

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -205,6 +205,39 @@ AppleAppStoreBackend * AppleAppStoreBackend::s_currentInstance = nullptr;
     }
 }
 
+-(void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error {
+    AppleAppStoreBackend* backend = AppleAppStoreBackend::s_currentInstance;
+    if (!backend) {
+        qWarning() << "TransactionObserver: Restore failed but no backend available";
+        return;
+    }
+
+    qDebug() << "iOS: Restore purchases failed with error code:" << error.code;
+
+    int errorCode = error.code;
+    AbstractStoreBackend::PurchaseError mappedError = mapStoreKitErrorToPurchaseError(errorCode);
+    QString message = getStoreKitErrorMessage(errorCode);
+
+    QMetaObject::invokeMethod(backend, "restorePurchasesFailed", Qt::AutoConnection,
+        Q_ARG(int, static_cast<int>(mappedError)),
+        Q_ARG(int, errorCode),
+        Q_ARG(QString, message));
+}
+
+-(void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {
+    AppleAppStoreBackend* backend = AppleAppStoreBackend::s_currentInstance;
+    if (!backend) {
+        qWarning() << "TransactionObserver: Restore completed but no backend available";
+        return;
+    }
+
+    int count = backend->restoredPurchasesCount();
+    qDebug() << "iOS: Restore purchases completed successfully. Count:" << count;
+
+    QMetaObject::invokeMethod(backend, "restorePurchasesSucceeded", Qt::AutoConnection,
+        Q_ARG(int, count));
+}
+
 @end
 
 @interface InAppPurchaseManager : NSObject <SKProductsRequestDelegate>
@@ -307,7 +340,12 @@ AppleAppStoreBackend::AppleAppStoreBackend(QObject * parent) : AbstractStoreBack
 {
     Q_ASSERT(QThread::currentThread() == QCoreApplication::instance()->thread());
     s_currentInstance = this;
-    
+
+    // Track restored purchases count for restoration completion reporting
+    connect(this, &AppleAppStoreBackend::purchaseRestored, this, [this](Transaction transaction){
+        _restoredPurchasesCount++;
+    });
+
     this->startConnection();
 }
 
@@ -367,9 +405,10 @@ void AppleAppStoreBackend::consumePurchase(Transaction transaction)
     }
 }
 
-void AppleAppStoreBackend::restorePurchases()
+void AppleAppStoreBackend::restorePurchasesImpl()
 {
-    qDebug() << "iOS restorePurchases() called - triggering SKPaymentQueue.restoreCompletedTransactions";
+    qDebug() << "iOS restorePurchasesImpl() called - triggering SKPaymentQueue.restoreCompletedTransactions";
+    _restoredPurchasesCount = 0;
     [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -40,8 +40,8 @@ static AbstractStoreBackend::PurchaseError mapStoreKitErrorToPurchaseError(int e
         case SKErrorPaymentNotAllowed:
             return AbstractStoreBackend::PurchaseError::NotAllowed;
         case SKErrorPaymentInvalid:
+        case SKErrorClientInvalid: // See https://stackoverflow.com/a/10975530/457584
             return AbstractStoreBackend::PurchaseError::PaymentInvalid;
-        case SKErrorClientInvalid:
         case SKErrorStoreProductNotAvailable:
             return AbstractStoreBackend::PurchaseError::ItemUnavailable;
         case SKErrorCloudServiceNetworkConnectionFailed:

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -39,6 +39,7 @@ public:
     Q_PROPERTY(bool connected READ isConnected NOTIFY connectedChanged FINAL)
     Q_PROPERTY(bool canMakePurchases READ canMakePurchases NOTIFY canMakePurchasesChanged FINAL)
     Q_PROPERTY(bool processingEnabled READ processingEnabled NOTIFY processingEnabledChanged FINAL)
+    Q_PROPERTY(bool isRestoringPurchases READ isRestoringPurchases NOTIFY isRestoringPurchasesChanged FINAL)
 
 public:
     QQmlListProperty<AbstractProduct> productsQml();
@@ -47,6 +48,7 @@ public:
     bool isConnected() const { return _connected; }
     virtual bool canMakePurchases() const = 0;
     bool processingEnabled() const { return _processingEnabled; }
+    bool isRestoringPurchases() const { return _isRestoringPurchases; }
 
     virtual void startConnection() = 0;
     virtual void registerProduct(AbstractProduct * product) = 0;
@@ -65,9 +67,11 @@ protected:
     bool _connected = false;
     bool _canMakePurchases = false;
     bool _processingEnabled = false;
+    bool _isRestoringPurchases = false;
 
     void setConnected(bool connected);
     void setCanMakePurchases(bool canMakePurchases);
+    void setIsRestoringPurchases(bool restoring);
 
 private:
     static void appendProduct(QQmlListProperty<AbstractProduct> *list, AbstractProduct *product);
@@ -80,6 +84,7 @@ signals:
     void connectedChanged();
     void canMakePurchasesChanged();
     void processingEnabledChanged();
+    void isRestoringPurchasesChanged();
 
     void productRegistered(AbstractProduct * product);
     void purchaseSucceeded(Transaction transaction);
@@ -88,6 +93,8 @@ signals:
     void purchaseFailed(const QString & productId, int error, int platformCode, const QString & message);
     void consumePurchaseSucceeded(Transaction transaction);
     void consumePurchaseFailed(Transaction transaction);
+    void restorePurchasesSucceeded(int count);
+    void restorePurchasesFailed(int error, int platformCode, const QString & message);
 };
 
 #endif // ABSTRACTSTOREBACKEND_H

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -56,7 +56,7 @@ public:
     virtual void purchaseProduct(AbstractProduct * product) = 0;
     virtual void consumePurchase(Transaction transaction) = 0;
 
-    Q_INVOKABLE virtual void restorePurchases();
+    Q_INVOKABLE void restorePurchases();
     Q_INVOKABLE virtual void finalize(Transaction transaction);
 
     // Transaction processing control (cross-platform defensive programming)
@@ -73,6 +73,9 @@ protected:
     void setConnected(bool connected);
     void setCanMakePurchases(bool canMakePurchases);
     void setIsRestoringPurchases(bool restoring);
+
+    // Platform-specific implementation called by restorePurchases()
+    virtual void restorePurchasesImpl() = 0;
 
 private:
     static void appendProduct(QQmlListProperty<AbstractProduct> *list, AbstractProduct *product);

--- a/src/include/qt6purchasing/abstractstorebackend.h
+++ b/src/include/qt6purchasing/abstractstorebackend.h
@@ -21,6 +21,7 @@ class AbstractStoreBackend : public QObject
 public:
     enum class PurchaseError {
         NoError,
+        Busy,
         UserCanceled,
         NetworkError,
         ServiceUnavailable,
@@ -55,7 +56,7 @@ public:
     virtual void purchaseProduct(AbstractProduct * product) = 0;
     virtual void consumePurchase(Transaction transaction) = 0;
 
-    Q_INVOKABLE virtual void restorePurchases() = 0;
+    Q_INVOKABLE virtual void restorePurchases();
     Q_INVOKABLE virtual void finalize(Transaction transaction);
 
     // Transaction processing control (cross-platform defensive programming)

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -332,30 +332,33 @@ void MicrosoftStoreBackend::consumePurchase(Transaction transaction)
     thread->start();
 }
 
-void MicrosoftStoreBackend::restorePurchases()
+void MicrosoftStoreBackend::restorePurchasesImpl()
 {
-    qDebug() << "restorePurchases() called, products count:" << products().size();
-    
+    qDebug() << "restorePurchasesImpl() called, products count:" << products().size();
+
     if (!isConnected()) {
         qWarning() << "Cannot restore purchases - store not connected";
+        emit restorePurchasesFailed(static_cast<int>(PurchaseError::ServiceUnavailable), 0, "Store not connected");
         return;
     }
-    
+
     if (!_hwnd) {
         qWarning() << "No window handle available for restore";
+        emit restorePurchasesFailed(static_cast<int>(PurchaseError::DeveloperError), 0, "No window handle available");
         return;
     }
-    
+
     auto* worker = new StoreRestoreWorker(_hwnd);
     auto* thread = new QThread(this);
-    
+
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreRestoreWorker::performRestore);
     connect(worker, &StoreRestoreWorker::restoreComplete, this, &MicrosoftStoreBackend::onRestoreComplete, Qt::QueuedConnection);
+    connect(worker, &StoreRestoreWorker::restoreFailed, this, &MicrosoftStoreBackend::onRestoreFailed, Qt::QueuedConnection);
     connect(worker, &StoreRestoreWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreRestoreWorker::finished, worker, &StoreRestoreWorker::deleteLater);
-    
+
     thread->start();
 }
 
@@ -370,6 +373,7 @@ void MicrosoftStoreBackend::onRestoreComplete(const QList<QVariantMap> &restored
         return;
     }
 
+    int restoredCount = 0;
     for (const auto& productData : restoredProducts) {
         QString msStoreId = productData["productId"].toString();
         QString orderId = QString("ms_restored_%1").arg(msStoreId);
@@ -388,11 +392,23 @@ void MicrosoftStoreBackend::onRestoreComplete(const QList<QVariantMap> &restored
             transaction.orderId = orderId;
             transaction.productId = qtIdentifier;
             emit purchaseRestored(transaction);
+            restoredCount++;
             qDebug() << "Restored purchase: MS Store ID" << msStoreId << "-> Qt ID" << qtIdentifier;
         } else {
             qWarning() << "Could not find Qt product for Microsoft Store ID:" << msStoreId;
         }
     }
+
+    emit restorePurchasesSucceeded(restoredCount);
+}
+
+void MicrosoftStoreBackend::onRestoreFailed(uint32_t errorCode, const QString & message)
+{
+    qDebug() << "onRestoreFailed: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
+    qWarning() << "Restore failed with error code:" << Qt::hex << errorCode << "Message:" << message;
+
+    PurchaseError mappedError = mapWindowsErrorToPurchaseError(errorCode);
+    emit restorePurchasesFailed(static_cast<int>(mappedError), errorCode, message);
 }
 
 void MicrosoftStoreBackend::onConsumableFulfillmentComplete(const QString & orderId, const QString & productId, bool success, const QString & result)

--- a/src/windows/microsoftstorebackend.h
+++ b/src/windows/microsoftstorebackend.h
@@ -21,7 +21,6 @@ public:
     void registerProduct(AbstractProduct * product) override;
     void purchaseProduct(AbstractProduct * product) override;
     void consumePurchase(Transaction transaction) override;
-    void restorePurchases() override;
     bool canMakePurchases() const override;
 
     // Transaction processing control
@@ -29,10 +28,14 @@ public:
 
     static MicrosoftStoreBackend * s_currentInstance;
 
+protected:
+    void restorePurchasesImpl() override;
+
 private slots:
     void onProductQueried(AbstractProduct * product, bool success, const QVariantMap & productData);
     void onPurchaseComplete(AbstractProduct * product, winrt::Windows::Services::Store::StorePurchaseStatus status);
     void onRestoreComplete(const QList<QVariantMap> &restoredProducts);
+    void onRestoreFailed(uint32_t errorCode, const QString & message);
     void onAllProductsQueried(const QList<QVariantMap> &products);
 
 private:

--- a/src/windows/microsoftstoreworkers.cpp
+++ b/src/windows/microsoftstoreworkers.cpp
@@ -111,42 +111,47 @@ void StoreRestoreWorker::performRestore()
     try {
         // Create StoreContext in worker thread
         auto storeContext = StoreContext::GetDefault();
-        
+
         // Initialize with window handle
         auto initWindow = storeContext.as<IInitializeWithWindow>();
         initWindow->Initialize(_hwnd);
-        
+
         // Get user's product collection
         std::vector<winrt::hstring> productKinds = { L"Durable", L"UnmanagedConsumable" };
         auto result = storeContext.GetUserCollectionAsync(std::move(productKinds)).get();
-        
+
         QList<QVariantMap> restoredProducts;
-        
+
         if (!result.ExtendedError()) {
             auto products = result.Products();
-            
+
             for (auto const& item : products) {
                 auto storeProduct = item.Value();
-                
+
                 QVariantMap productData;
                 productData["storeId"] = QString::fromWCharArray(storeProduct.StoreId().c_str());
                 productData["productId"] = QString::fromWCharArray(item.Key().c_str());
                 productData["title"] = QString::fromWCharArray(storeProduct.Title().c_str());
                 productData["productKind"] = QString::fromWCharArray(storeProduct.ProductKind().c_str());
-                
+
                 restoredProducts.append(productData);
             }
+            emit restoreComplete(restoredProducts);
+        } else {
+            uint32_t errorCode = result.ExtendedError().value;
+            qWarning() << "Windows Store restore error:" << Qt::hex << errorCode;
+            emit restoreFailed(errorCode, QString("Windows Store API error: 0x%1").arg(errorCode, 0, 16));
         }
-        
-        emit restoreComplete(restoredProducts);
     } catch (const winrt::hresult_error& e) {
-        qWarning() << "Exception in restore:" << QString::fromWCharArray(e.message().c_str());
-        emit restoreComplete(QList<QVariantMap>());
+        uint32_t errorCode = static_cast<uint32_t>(e.code().value);
+        QString message = QString::fromWCharArray(e.message().c_str());
+        qWarning() << "Exception in restore:" << message << "Code:" << Qt::hex << errorCode;
+        emit restoreFailed(errorCode, message);
     } catch (...) {
         qWarning() << "Unknown exception in restore";
-        emit restoreComplete(QList<QVariantMap>());
+        emit restoreFailed(0xFFFFFFFF, "Unknown exception during restore");
     }
-    
+
     emit finished();
 }
 

--- a/src/windows/microsoftstoreworkers.h
+++ b/src/windows/microsoftstoreworkers.h
@@ -73,6 +73,7 @@ public slots:
 
 signals:
     void restoreComplete(const QList<QVariantMap> &restoredProducts);
+    void restoreFailed(uint32_t errorCode, const QString & message);
     void finished();
 };
 


### PR DESCRIPTION
Implements and resolves #35.

Prior to this PR, restoring purchases would result in `purchaseRestored` signals correctly, but we would never know when the process had completed or if it had failed. Most notably, if there were no purchases to restore, this wasn't captured.

## Changes

- `AbstractStoreBackend` has 2 new signals:
   - `restorePurchasesSucceeded` which provides the `count` as a parameter. If the 'restore purchases' process completes but there were no purchases to restore, this signal will be emitted with count zero;
   - `restorePurchasesFailed` with error codes & message parameters like other failure signals.
- There is a process to avoid starting a 'restore purchases' process while one is already running. `restorePurchases()` checks the new property `isRestoringPurchases` and emits `restorePurchasesFailed()` with a new error code `PurchaseError::Busy` if one is already in progress. This is all managed automatically in the `AbstractStoreBackend` base class, and `isRestoringPurchases` is exposed as a readonly property.
- `README` adds information and usage guidance about these signals and properties, and also clarifies differences in process, timing and behaviour between the platforms.

## Also
- For Apple error codes:
   - `SKErrorClientInvalid` is now treated as `PaymentInvalid` not `ItemUnavailable` because it can happen as a result of user behaviour at the payment stage. It should be noted that this becomes more nuanced, and may need refining, if subscriptions are supported. (See https://stackoverflow.com/a/10975530/457584)
   - `SKErrorInvalidSignature` is now handled and is treated as `PaymentInvalid` because it occurs when the cryptographic signature against a promo code is invalid.
