### PR TITLE
Refine error handling + fix Windows restorePurchasesSucceeded

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ Store {
 - Transaction signals emitted before products exist cause "Failed to map purchase to product" errors
 
 **Platform-Specific Behavior:**
-- **iOS**: Queues early transactions, processes when enabled. Does not automatically restore purchases on startup.
-- **Android**: Queues Google Play callbacks, processes when enabled. Automatically queries purchases on connection (individual `purchaseRestored` signals are queued, but `restorePurchasesSucceeded`/`restorePurchasesFailed` signals may fire before processing is enabled).
-- **Windows**: Queues Store completion events, processes when enabled. Automatically restores purchases after product query completes (all signals are queued until processing is enabled).
+- **iOS**: Queues early transactions, processing them when enabled. Does not automatically restore purchases on startup.
+- **Android**: Queues Google Play callbacks, processing them when enabled. Automatically queries purchases on connection (individual `purchaseRestored` signals are queued, but `restorePurchasesSucceeded`/`restorePurchasesFailed` signals may fire before processing is enabled).
+- **Windows**: Queues Store completion events, processing them when enabled. Automatically restores purchases after product query completes (`purchaseRestored` and `restorePurchasesSucceeded` signals are queued, but `restorePurchasesFailed` signal may fire before processing is enabled).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -426,9 +426,9 @@ Qt6Purchasing.Store {
 ### Platform-specific restore behaviors
 
 **Automatic vs Manual Restore:**
-- **iOS**: Manual only. Call `store.restorePurchases()` when needed (e.g., from a "Restore Purchases" button). Best practice: wait until after `enableProcessing()` has been called to ensure proper signal delivery.
+- **iOS**: Manual only. Call `store.restorePurchases()` when needed (e.g., from a "Restore Purchases" button). Wait until after `enableProcessing()` has been called to ensure proper signal delivery.
 - **Android**: Automatic on connection. Also supports manual `store.restorePurchases()` calls. Note that automatic restore on startup may emit `restorePurchasesSucceeded`/`restorePurchasesFailed` before processing is enabled, though individual `purchaseRestored` signals are queued properly.
-- **Windows**: Automatic after product query. Also supports manual `store.restorePurchases()` calls. All restore-related signals are queued until processing is enabled.
+- **Windows**: Automatic after product query. Also supports manual `store.restorePurchases()` calls. Note that automatic restore on startup may emit `restorePurchasesFailed` before processing is enabled; `restorePurchasesSucceeded` and individual `purchaseRestored` signals are queued properly.
 
 **Platform APIs:**
 - **iOS**: `SKPaymentQueue.restoreCompletedTransactions()`. Reports success when restore completes, even if 0 purchases found.
@@ -472,9 +472,9 @@ Understanding these scenarios is critical for robust production deployment:
 - **Android**: Unacknowledged purchases remain available via `queryPurchases()` on startup.
 - **Windows**: Unfulfilled consumables remain in purchase history until consumed.
 
-**Library behaviour**: Automatically detects unfinished transactions on next app launch. Delivers them via `purchaseRestored` signal during startup. Maintains transaction queue integrity across app sessions.
+**Library behaviour**: Automatically detects unfinished transactions on next app launch. **iOS** delivers them via `purchaseSucceeded` signal (same as new purchases). **Android** & **Windows** delivers them via `purchaseRestored` signal, as they both perform an automatic "Restore Purchases" during startup. This maintains transaction queue integrity across app sessions.
 
-**Developer action**: Always handle `onPurchaseRestored` the same way as `onPurchaseSucceeded`. Call `store.finalize(transaction)` in both handlers. Implement idempotent content delivery - check if user already has the purchased item before granting it again.
+**Developer action**: Always handle both `onPurchaseSucceeded` and `onPurchaseRestored` identically - they both deliver transactions that need fulfillment. Call `store.finalize(transaction)` in both handlers. Implement idempotent content delivery - check if user already has the purchased item before granting it again.
 
 ### 4. Consumable Purchase Without Consumption
 **What happens**: Purchase succeeds but `store.finalize(transaction)` is never called (due to app crashes, network issues, or code bugs).
@@ -521,9 +521,9 @@ Understanding these scenarios is critical for robust production deployment:
 - **Windows**: Microsoft account-based restore with purchases tied to specific Microsoft account and device family. Store API errors are reported via `restorePurchasesFailed`. Automatically restores purchases after initial product query.
 
 **Library behaviour**:
-- **Windows**: Automatically calls restore after product query completes. All restore signals (including `restorePurchasesSucceeded`/`restorePurchasesFailed`) are queued until `enableProcessing()` is called.
+- **Windows**: Automatically calls restore after product query completes. Restore signals `purchaseRestored` and `restorePurchasesSucceeded` are queued, but `restorePurchasesFailed` may be emitted before `enableProcessing()`.
 - **Android**: Automatically queries purchases on billing service connection. Individual `purchaseRestored` signals are queued, but `restorePurchasesSucceeded`/`restorePurchasesFailed` may be emitted before `enableProcessing()`.
-- **iOS**: Does not automatically restore. Call `store.restorePurchases()` manually (best practice: after `enableProcessing()` has been called).
+- **iOS**: Does not automatically restore. Call `store.restorePurchases()` manually (after `enableProcessing()` has been called).
 - All platforms deliver available restored purchases via `purchaseRestored` signals
 - Emits `restorePurchasesSucceeded(count)` when restore completes successfully (count may be 0)
 - Emits `restorePurchasesFailed(error, platformCode, message)` on errors (network, authentication, service unavailable, etc.)

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -36,6 +36,7 @@ static AbstractStoreBackend::PurchaseError mapStoreKitErrorToPurchaseError(int e
 {
     switch (errorCode) {
         case SKErrorPaymentCancelled:
+        case SKErrorOverlayCancelled:
             return AbstractStoreBackend::PurchaseError::UserCanceled;
         case SKErrorPaymentNotAllowed:
             return AbstractStoreBackend::PurchaseError::NotAllowed;
@@ -44,10 +45,15 @@ static AbstractStoreBackend::PurchaseError mapStoreKitErrorToPurchaseError(int e
         case SKErrorInvalidSignature: // Cryptographic signature against promo code is invalid
             return AbstractStoreBackend::PurchaseError::PaymentInvalid;
         case SKErrorStoreProductNotAvailable:
+        case SKErrorInvalidOfferPrice:
             return AbstractStoreBackend::PurchaseError::ItemUnavailable;
         case SKErrorCloudServiceNetworkConnectionFailed:
         case SKErrorCloudServiceRevoked:
             return AbstractStoreBackend::PurchaseError::NetworkError;
+        case SKErrorUnauthorizedRequestData:
+        case SKErrorInvalidOfferIdentifier:
+        case SKErrorMissingOfferParams:
+            return AbstractStoreBackend::PurchaseError::DeveloperError;
         case SKErrorUnknown:
         default:
             return AbstractStoreBackend::PurchaseError::UnknownError;

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -79,14 +79,15 @@ void MicrosoftStoreBackend::queryAllProducts()
     
     auto* worker = new StoreAllProductsWorker(_hwnd);
     auto* thread = new QThread(this);
-    
+
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreAllProductsWorker::performQuery);
-    connect(worker, &StoreAllProductsWorker::queryComplete, this, &MicrosoftStoreBackend::onAllProductsQueried, Qt::QueuedConnection);
+    connect(worker, &StoreAllProductsWorker::querySucceeded, this, &MicrosoftStoreBackend::onAllProductsQueried, Qt::QueuedConnection);
+    connect(worker, &StoreAllProductsWorker::queryFailed, this, &MicrosoftStoreBackend::onAllProductsQueryFailed, Qt::QueuedConnection);
     connect(worker, &StoreAllProductsWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreAllProductsWorker::finished, worker, &StoreAllProductsWorker::deleteLater);
-    
+
     thread->start();
 }
 
@@ -97,9 +98,18 @@ void MicrosoftStoreBackend::onAllProductsQueried(const QList<QVariantMap> &produ
         qDebug() << "Available product:" << product["productId"].toString()
                  << "Title:" << product["title"].toString();
     }
-    
+
     // Now that products are available, restore existing purchases
     qDebug() << "Products queried, now calling restorePurchases()";
+    restorePurchases();
+}
+
+void MicrosoftStoreBackend::onAllProductsQueryFailed(uint32_t hresult, const QString & message)
+{
+    qWarning() << "Failed to query all products - HRESULT:" << Qt::hex << Qt::showbase << hresult
+               << "Message:" << message;
+    // Continue anyway - this is just diagnostic info
+    // Still try to restore purchases even if we couldn't enumerate products
     restorePurchases();
 }
 
@@ -129,65 +139,71 @@ void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
     
     auto* worker = new StoreProductQueryWorker(productId, _hwnd);
     auto* thread = new QThread(this);
-    
+
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreProductQueryWorker::performQuery);
-    connect(worker, &StoreProductQueryWorker::queryComplete, this,
-            [this, product](bool success, const QVariantMap& productData) {
-                this->onProductQueried(product, success, productData);
+    connect(worker, &StoreProductQueryWorker::querySucceeded, this,
+            [this, product](const QVariantMap& productData) {
+                this->onProductQuerySucceeded(product, productData);
+            }, Qt::QueuedConnection);
+    connect(worker, &StoreProductQueryWorker::queryFailed, this,
+            [this, product](uint32_t hresult, const QString& message) {
+                this->onProductQueryFailed(product, hresult, message);
             }, Qt::QueuedConnection);
     connect(worker, &StoreProductQueryWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreProductQueryWorker::finished, worker, &StoreProductQueryWorker::deleteLater);
-    
+
     thread->start();
 }
 
-void MicrosoftStoreBackend::onProductQueried(AbstractProduct * product, bool success, const QVariantMap & productData)
+void MicrosoftStoreBackend::onProductQuerySucceeded(AbstractProduct * product, const QVariantMap & productData)
 {
-    if (success) {
-        auto msProduct = qobject_cast<MicrosoftStoreProduct*>(product);
-        if (msProduct) {
-            // Set product data
-            product->setTitle(productData["title"].toString());
-            product->setDescription(productData["description"].toString());
-            product->setPrice(productData["price"].toString());
-            
-            // Validate product type matches store configuration
-            QString productKind = productData["productKind"].toString();
-            AbstractProduct::ProductType storeType;
-            if (productKind == "Durable") {
-                storeType = AbstractProduct::Unlockable;
-            } else if (productKind == "UnmanagedConsumable") {
-                storeType = AbstractProduct::Consumable;
-            } else {
-                qCritical() << "Unknown Microsoft Store product kind:" << productKind << "for product:" << product->identifier();
-                product->setStatus(AbstractProduct::Unknown);
-                return;
-            }
+    auto msProduct = qobject_cast<MicrosoftStoreProduct*>(product);
+    if (msProduct) {
+        // Set product data
+        product->setTitle(productData["title"].toString());
+        product->setDescription(productData["description"].toString());
+        product->setPrice(productData["price"].toString());
 
-            if (storeType != product->productType()) {
-                qCritical() << "Product type mismatch!" << product->identifier() 
-                            << "Microsoft Store ID:" << productData["storeId"].toString()
-                            << "Expected:" << (product->productType() == AbstractProduct::Consumable ? "Consumable" :
-                                             product->productType() == AbstractProduct::Unlockable ? "Unlockable" : "None")
-                            << "Store reports:" << productKind;
-                product->setStatus(AbstractProduct::IncorrectProductType);
-                return;
-            }
-            
-            // Track the product for later reference
-            _registeredProducts[product->identifier()] = product;
-            
-            product->setStatus(AbstractProduct::Registered);
-            emit productRegistered(product);
-            
-            qDebug() << "Product registered successfully:" << product->identifier();
+        // Validate product type matches store configuration
+        QString productKind = productData["productKind"].toString();
+        AbstractProduct::ProductType storeType;
+        if (productKind == "Durable") {
+            storeType = AbstractProduct::Unlockable;
+        } else if (productKind == "UnmanagedConsumable") {
+            storeType = AbstractProduct::Consumable;
+        } else {
+            qCritical() << "Unknown Microsoft Store product kind:" << productKind << "for product:" << product->identifier();
+            product->setStatus(AbstractProduct::Unknown);
+            return;
         }
-    } else {
-        qWarning() << "Product not found in store:" << product->identifier();
-        product->setStatus(AbstractProduct::Unknown);
+
+        if (storeType != product->productType()) {
+            qCritical() << "Product type mismatch!" << product->identifier()
+                        << "Microsoft Store ID:" << productData["storeId"].toString()
+                        << "Expected:" << (product->productType() == AbstractProduct::Consumable ? "Consumable" :
+                                         product->productType() == AbstractProduct::Unlockable ? "Unlockable" : "None")
+                        << "Store reports:" << productKind;
+            product->setStatus(AbstractProduct::IncorrectProductType);
+            return;
+        }
+
+        // Track the product for later reference
+        _registeredProducts[product->identifier()] = product;
+
+        product->setStatus(AbstractProduct::Registered);
+        emit productRegistered(product);
+
+        qDebug() << "Product registered successfully:" << product->identifier();
     }
+}
+
+void MicrosoftStoreBackend::onProductQueryFailed(AbstractProduct * product, uint32_t hresult, const QString & message)
+{
+    qWarning() << "Product query failed for:" << product->identifier()
+               << "HRESULT:" << Qt::hex << Qt::showbase << hresult << "Message:" << message;
+    product->setStatus(AbstractProduct::Unknown);
 }
 
 void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
@@ -307,28 +323,36 @@ void MicrosoftStoreBackend::consumePurchase(Transaction transaction)
     // Create fulfillment worker
     auto* worker = new StoreConsumableFulfillmentWorker(storeId, 1, _hwnd); // quantity = 1
     auto* thread = new QThread(this);
-    
+
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreConsumableFulfillmentWorker::performFulfillment);
-    
+
     // Capture transaction data by value for logging
     QString orderId = transaction.orderId;
     QString productId = transaction.productId;
-    connect(worker, &StoreConsumableFulfillmentWorker::fulfillmentComplete, this,
-            [this, transaction, orderId, productId](bool success, const QString& result) {
-                this->onConsumableFulfillmentComplete(orderId, productId, success, result);
-                
-                // Emit appropriate signal based on fulfillment result
-                if (success) {
-                    emit consumePurchaseSucceeded(transaction);
-                } else {
-                    emit consumePurchaseFailed(transaction);
+    connect(worker, &StoreConsumableFulfillmentWorker::fulfillmentSucceeded, this,
+            [this, transaction, orderId, productId]() {
+                qDebug() << "Consumable fulfillment completed successfully for product:" << productId << "order:" << orderId;
+                emit consumePurchaseSucceeded(transaction);
+            }, Qt::QueuedConnection);
+    connect(worker, &StoreConsumableFulfillmentWorker::fulfillmentFailed, this,
+            [this, transaction, orderId, productId](uint32_t errorCode, const QString& message) {
+                qWarning() << "Consumable fulfillment failed for product:" << productId << "order:" << orderId
+                           << "Error code:" << Qt::hex << Qt::showbase << errorCode << "Message:" << message;
+
+                // Check if this is a debug mode limitation
+                if (message.contains("Server error") || errorCode == 0x803f6107) {
+                    qWarning() << "Note: Fulfillment errors are common in debug mode. "
+                               << "This app needs to be properly packaged and signed for the Microsoft Store "
+                               << "for consumable fulfillment to work correctly.";
                 }
+
+                emit consumePurchaseFailed(transaction);
             }, Qt::QueuedConnection);
     connect(worker, &StoreConsumableFulfillmentWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
     connect(worker, &StoreConsumableFulfillmentWorker::finished, worker, &StoreConsumableFulfillmentWorker::deleteLater);
-    
+
     thread->start();
 }
 
@@ -353,7 +377,7 @@ void MicrosoftStoreBackend::restorePurchasesImpl()
 
     worker->moveToThread(thread);
     connect(thread, &QThread::started, worker, &StoreRestoreWorker::performRestore);
-    connect(worker, &StoreRestoreWorker::restoreComplete, this, &MicrosoftStoreBackend::onRestoreComplete, Qt::QueuedConnection);
+    connect(worker, &StoreRestoreWorker::restoreSucceeded, this, &MicrosoftStoreBackend::onRestoreSucceeded, Qt::QueuedConnection);
     connect(worker, &StoreRestoreWorker::restoreFailed, this, &MicrosoftStoreBackend::onRestoreFailed, Qt::QueuedConnection);
     connect(worker, &StoreRestoreWorker::finished, thread, &QThread::quit);
     connect(thread, &QThread::finished, thread, &QThread::deleteLater);
@@ -362,10 +386,10 @@ void MicrosoftStoreBackend::restorePurchasesImpl()
     thread->start();
 }
 
-void MicrosoftStoreBackend::onRestoreComplete(const QList<QVariantMap> &restoredProducts)
+void MicrosoftStoreBackend::onRestoreSucceeded(const QList<QVariantMap> &restoredProducts)
 {
-    qDebug() << "onRestoreComplete: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
-    qDebug() << "Restore complete, found" << restoredProducts.size() << "owned products";
+    qDebug() << "onRestoreSucceeded: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
+    qDebug() << "Restore succeeded, found" << restoredProducts.size() << "owned products";
 
     if (!processingEnabled()) {
         qDebug() << "Windows: onRestoreComplete received but processing not enabled - queueing";
@@ -407,27 +431,8 @@ void MicrosoftStoreBackend::onRestoreFailed(uint32_t errorCode, const QString & 
     qDebug() << "onRestoreFailed: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
     qWarning() << "Restore failed with error code:" << Qt::hex << errorCode << "Message:" << message;
 
-    PurchaseError mappedError = mapWindowsErrorToPurchaseError(errorCode);
+    PurchaseError mappedError = mapHRESULTToPurchaseError(errorCode);
     emit restorePurchasesFailed(static_cast<int>(mappedError), errorCode, message);
-}
-
-void MicrosoftStoreBackend::onConsumableFulfillmentComplete(const QString & orderId, const QString & productId, bool success, const QString & result)
-{
-    if (success) {
-        qDebug() << "Consumable fulfillment completed successfully for product:" << productId << "order:" << orderId;
-    } else {
-        qWarning() << "Consumable fulfillment failed for product:" << productId << "order:" << orderId
-                   << "Error:" << result;
-        
-        // Check if this is a debug mode limitation
-        if (result.contains("Server error") || result.contains("0x803f6107")) {
-            qWarning() << "Note: Fulfillment errors are common in debug mode. "
-                       << "This app needs to be properly packaged and signed for the Microsoft Store "
-                       << "for consumable fulfillment to work correctly.";
-        }
-    }
-    
-    // Note: consumePurchase success/failure signals are now emitted in the lambda to ensure transaction validity
 }
 
 bool MicrosoftStoreBackend::canMakePurchases() const
@@ -469,6 +474,24 @@ QString MicrosoftStoreBackend::getWindowsErrorMessage(uint32_t statusCode)
             return "Microsoft Store server error occurred";
         default:
             return QString("Unknown Windows StorePurchaseStatus: %1").arg(statusCode);
+    }
+}
+
+AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapHRESULTToPurchaseError(uint32_t hresult)
+{
+    switch (hresult) {
+        case 0x80070525: // ERROR_NO_SUCH_USER
+            return PurchaseError::NotAllowed;
+        case 0x803F6107: // Store licensing error
+            return PurchaseError::DeveloperError;
+        case 0x80072EFD: // WININET_E_CANNOT_CONNECT (network connectivity)
+            return PurchaseError::NetworkError;
+        case 0x80004005: // E_FAIL (generic failure)
+            return PurchaseError::UnknownError;
+        case 0x80070005: // E_ACCESSDENIED (access denied)
+            return PurchaseError::ServiceUnavailable;
+        default:
+            return PurchaseError::UnknownError;
     }
 }
 

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -265,19 +265,7 @@ void MicrosoftStoreBackend::onPurchaseComplete(AbstractProduct * product, StoreP
         return;
     }
 
-    if (status == StorePurchaseStatus::Succeeded) {
-        // Create transaction data for success
-        Transaction transaction;
-        transaction.orderId = QString("ms_%1_%2").arg(product->identifier()).arg(QDateTime::currentMSecsSinceEpoch());
-        transaction.productId = product->identifier();
-        emit purchaseSucceeded(transaction);
-    } else {
-        // Use the real Windows StorePurchaseStatus as platform code
-        PurchaseError error = mapWindowsErrorToPurchaseError(static_cast<uint32_t>(status));
-        QString message = getWindowsErrorMessage(static_cast<uint32_t>(status));
-        QString productId = product->identifier();
-        emit purchaseFailed(productId, static_cast<int>(error), static_cast<uint32_t>(status), message);
-    }
+    processPurchase(product, status);
 }
 
 void MicrosoftStoreBackend::consumePurchase(Transaction transaction)
@@ -393,37 +381,11 @@ void MicrosoftStoreBackend::onRestoreSucceeded(const QList<QVariantMap> &restore
 
     if (!processingEnabled()) {
         qDebug() << "Windows: onRestoreComplete received but processing not enabled - queueing";
-        _queuedRestores.append({restoredProducts});
+        _queuedRestores = restoredProducts;
         return;
     }
 
-    int restoredCount = 0;
-    for (const auto& productData : restoredProducts) {
-        QString msStoreId = productData["productId"].toString();
-        QString orderId = QString("ms_restored_%1").arg(msStoreId);
-
-        // Find the Qt identifier by searching registered products
-        QString qtIdentifier;
-        for (AbstractProduct * product : products()) {
-            if (product->microsoftStoreId() == msStoreId) {
-                qtIdentifier = product->identifier();
-                break;
-            }
-        }
-
-        if (!qtIdentifier.isEmpty()) {
-            Transaction transaction;
-            transaction.orderId = orderId;
-            transaction.productId = qtIdentifier;
-            emit purchaseRestored(transaction);
-            restoredCount++;
-            qDebug() << "Restored purchase: MS Store ID" << msStoreId << "-> Qt ID" << qtIdentifier;
-        } else {
-            qWarning() << "Could not find Qt product for Microsoft Store ID:" << msStoreId;
-        }
-    }
-
-    emit restorePurchasesSucceeded(restoredCount);
+    processRestoredProducts(restoredProducts);
 }
 
 void MicrosoftStoreBackend::onRestoreFailed(uint32_t errorCode, const QString & message)
@@ -512,45 +474,59 @@ void MicrosoftStoreBackend::processQueuedTransactions()
              << _queuedRestores.size() << "queued restores";
 
     // Process queued purchases
-    for (const auto& queuedPurchase : _queuedPurchases) {
-        if (queuedPurchase.status == StorePurchaseStatus::Succeeded) {
-            Transaction transaction;
-            transaction.orderId = QString("ms_%1_%2").arg(queuedPurchase.product->identifier()).arg(QDateTime::currentMSecsSinceEpoch());
-            transaction.productId = queuedPurchase.product->identifier();
-            emit purchaseSucceeded(transaction);
-        } else {
-            PurchaseError error = mapWindowsErrorToPurchaseError(static_cast<uint32_t>(queuedPurchase.status));
-            QString message = getWindowsErrorMessage(static_cast<uint32_t>(queuedPurchase.status));
-            QString productId = queuedPurchase.product->identifier();
-            emit purchaseFailed(productId, static_cast<int>(error), static_cast<uint32_t>(queuedPurchase.status), message);
-        }
-    }
+    for (const auto& queuedPurchase : _queuedPurchases)
+        processPurchase(queuedPurchase.product, queuedPurchase.status);
     _queuedPurchases.clear();
 
     // Process queued restores
-    for (const auto& queuedRestore : _queuedRestores) {
-        for (const auto& productData : queuedRestore.restoredProducts) {
-            QString msStoreId = productData["productId"].toString();
-            QString orderId = QString("ms_restored_%1").arg(msStoreId);
+    processRestoredProducts(_queuedRestores);
+    _queuedRestores.clear();
+}
 
-            QString qtIdentifier;
-            for (AbstractProduct * product : products()) {
-                if (product->microsoftStoreId() == msStoreId) {
-                    qtIdentifier = product->identifier();
-                    break;
-                }
-            }
+void MicrosoftStoreBackend::processPurchase(AbstractProduct * product, StorePurchaseStatus status)
+{
+    if (status == StorePurchaseStatus::Succeeded) {
+        // Create transaction data for success
+        Transaction transaction;
+        transaction.orderId = QString("ms_%1_%2").arg(product->identifier()).arg(QDateTime::currentMSecsSinceEpoch());
+        transaction.productId = product->identifier();
+        emit purchaseSucceeded(transaction);
+    } else {
+        // Use the real Windows StorePurchaseStatus as platform code
+        PurchaseError error = mapWindowsErrorToPurchaseError(static_cast<uint32_t>(status));
+        QString message = getWindowsErrorMessage(static_cast<uint32_t>(status));
+        QString productId = product->identifier();
+        emit purchaseFailed(productId, static_cast<int>(error), static_cast<uint32_t>(status), message);
+    }
+}
 
-            if (!qtIdentifier.isEmpty()) {
-                Transaction transaction;
-                transaction.orderId = orderId;
-                transaction.productId = qtIdentifier;
-                emit purchaseRestored(transaction);
-                qDebug() << "Processing queued restore: MS Store ID" << msStoreId << "-> Qt ID" << qtIdentifier;
-            } else {
-                qWarning() << "Could not find Qt product for queued restore Microsoft Store ID:" << msStoreId;
+void MicrosoftStoreBackend::processRestoredProducts(const QList<QVariantMap> &restoredProducts)
+{
+    int restoredCount = 0;
+    for (const auto& productData : restoredProducts) {
+        QString msStoreId = productData["productId"].toString();
+        QString orderId = QString("ms_restored_%1").arg(msStoreId);
+
+        // Find the Qt identifier by searching registered products
+        QString qtIdentifier;
+        for (AbstractProduct * product : products()) {
+            if (product->microsoftStoreId() == msStoreId) {
+                qtIdentifier = product->identifier();
+                break;
             }
         }
+
+        if (!qtIdentifier.isEmpty()) {
+            Transaction transaction;
+            transaction.orderId = orderId;
+            transaction.productId = qtIdentifier;
+            emit purchaseRestored(transaction);
+            restoredCount++;
+            qDebug() << "Restored purchase: MS Store ID" << msStoreId << "-> Qt ID" << qtIdentifier;
+        } else {
+            qWarning() << "Could not find Qt product for Microsoft Store ID:" << msStoreId;
+        }
     }
-    _queuedRestores.clear();
+
+    emit restorePurchasesSucceeded(restoredCount);
 }

--- a/src/windows/microsoftstorebackend.cpp
+++ b/src/windows/microsoftstorebackend.cpp
@@ -36,25 +36,6 @@ MicrosoftStoreBackend::~MicrosoftStoreBackend()
     qDebug() << "Destroying Microsoft Store backend";
 }
 
-void MicrosoftStoreBackend::initializeWindowHandle()
-{
-    auto app = qobject_cast<QGuiApplication*>(QCoreApplication::instance());
-    if (!app) {
-        qDebug() << "No QGuiApplication instance found";
-        return;
-    }
-    
-    auto windows = app->topLevelWindows();
-    if (!windows.isEmpty()) {
-        auto window = windows.first();
-        if (window) {
-            // For QWindow, we just get the winId which creates the native window
-            _hwnd = reinterpret_cast<HWND>(window->winId());
-            qDebug() << "Cached window handle:" << _hwnd;
-        }
-    }
-}
-
 void MicrosoftStoreBackend::startConnection()
 {
     qDebug() << "Initializing Microsoft Store connection";
@@ -68,49 +49,6 @@ void MicrosoftStoreBackend::startConnection()
     queryAllProducts();
     
     // Note: restorePurchases() will be called after products are queried
-}
-
-void MicrosoftStoreBackend::queryAllProducts()
-{
-    if (!_hwnd) {
-        qWarning() << "No window handle available for Store query";
-        return;
-    }
-    
-    auto* worker = new StoreAllProductsWorker(_hwnd);
-    auto* thread = new QThread(this);
-
-    worker->moveToThread(thread);
-    connect(thread, &QThread::started, worker, &StoreAllProductsWorker::performQuery);
-    connect(worker, &StoreAllProductsWorker::querySucceeded, this, &MicrosoftStoreBackend::onAllProductsQueried, Qt::QueuedConnection);
-    connect(worker, &StoreAllProductsWorker::queryFailed, this, &MicrosoftStoreBackend::onAllProductsQueryFailed, Qt::QueuedConnection);
-    connect(worker, &StoreAllProductsWorker::finished, thread, &QThread::quit);
-    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
-    connect(worker, &StoreAllProductsWorker::finished, worker, &StoreAllProductsWorker::deleteLater);
-
-    thread->start();
-}
-
-void MicrosoftStoreBackend::onAllProductsQueried(const QList<QVariantMap> &products)
-{
-    qDebug() << "Store query completed, found" << products.size() << "products";
-    for (const auto& product : products) {
-        qDebug() << "Available product:" << product["productId"].toString()
-                 << "Title:" << product["title"].toString();
-    }
-
-    // Now that products are available, restore existing purchases
-    qDebug() << "Products queried, now calling restorePurchases()";
-    restorePurchases();
-}
-
-void MicrosoftStoreBackend::onAllProductsQueryFailed(uint32_t hresult, const QString & message)
-{
-    qWarning() << "Failed to query all products - HRESULT:" << Qt::hex << Qt::showbase << hresult
-               << "Message:" << message;
-    // Continue anyway - this is just diagnostic info
-    // Still try to restore purchases even if we couldn't enumerate products
-    restorePurchases();
 }
 
 void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
@@ -155,55 +93,6 @@ void MicrosoftStoreBackend::registerProduct(AbstractProduct * product)
     connect(worker, &StoreProductQueryWorker::finished, worker, &StoreProductQueryWorker::deleteLater);
 
     thread->start();
-}
-
-void MicrosoftStoreBackend::onProductQuerySucceeded(AbstractProduct * product, const QVariantMap & productData)
-{
-    auto msProduct = qobject_cast<MicrosoftStoreProduct*>(product);
-    if (msProduct) {
-        // Set product data
-        product->setTitle(productData["title"].toString());
-        product->setDescription(productData["description"].toString());
-        product->setPrice(productData["price"].toString());
-
-        // Validate product type matches store configuration
-        QString productKind = productData["productKind"].toString();
-        AbstractProduct::ProductType storeType;
-        if (productKind == "Durable") {
-            storeType = AbstractProduct::Unlockable;
-        } else if (productKind == "UnmanagedConsumable") {
-            storeType = AbstractProduct::Consumable;
-        } else {
-            qCritical() << "Unknown Microsoft Store product kind:" << productKind << "for product:" << product->identifier();
-            product->setStatus(AbstractProduct::Unknown);
-            return;
-        }
-
-        if (storeType != product->productType()) {
-            qCritical() << "Product type mismatch!" << product->identifier()
-                        << "Microsoft Store ID:" << productData["storeId"].toString()
-                        << "Expected:" << (product->productType() == AbstractProduct::Consumable ? "Consumable" :
-                                         product->productType() == AbstractProduct::Unlockable ? "Unlockable" : "None")
-                        << "Store reports:" << productKind;
-            product->setStatus(AbstractProduct::IncorrectProductType);
-            return;
-        }
-
-        // Track the product for later reference
-        _registeredProducts[product->identifier()] = product;
-
-        product->setStatus(AbstractProduct::Registered);
-        emit productRegistered(product);
-
-        qDebug() << "Product registered successfully:" << product->identifier();
-    }
-}
-
-void MicrosoftStoreBackend::onProductQueryFailed(AbstractProduct * product, uint32_t hresult, const QString & message)
-{
-    qWarning() << "Product query failed for:" << product->identifier()
-               << "HRESULT:" << Qt::hex << Qt::showbase << hresult << "Message:" << message;
-    product->setStatus(AbstractProduct::Unknown);
 }
 
 void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
@@ -253,19 +142,6 @@ void MicrosoftStoreBackend::purchaseProduct(AbstractProduct * product)
     connect(worker, &StorePurchaseWorker::finished, worker, &StorePurchaseWorker::deleteLater);
 
     thread->start();
-}
-
-void MicrosoftStoreBackend::onPurchaseComplete(AbstractProduct * product, StorePurchaseStatus status)
-{
-    qDebug() << "onPurchaseComplete: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
-
-    if (!processingEnabled()) {
-        qDebug() << "Windows: onPurchaseComplete received but processing not enabled - queueing";
-        _queuedPurchases.append({product, status});
-        return;
-    }
-
-    processPurchase(product, status);
 }
 
 void MicrosoftStoreBackend::consumePurchase(Transaction transaction)
@@ -344,6 +220,23 @@ void MicrosoftStoreBackend::consumePurchase(Transaction transaction)
     thread->start();
 }
 
+bool MicrosoftStoreBackend::canMakePurchases() const
+{
+    // For Windows, we can make purchases if we're connected to the store
+    return isConnected();
+}
+
+void MicrosoftStoreBackend::enableProcessing()
+{
+    if (processingEnabled())
+        return;
+
+    AbstractStoreBackend::enableProcessing();
+
+    qDebug() << "Windows: Processing enabled - processing queued transactions";
+    processQueuedTransactions();
+}
+
 void MicrosoftStoreBackend::restorePurchasesImpl()
 {
     qDebug() << "restorePurchasesImpl() called, products count:" << products().size();
@@ -374,6 +267,68 @@ void MicrosoftStoreBackend::restorePurchasesImpl()
     thread->start();
 }
 
+void MicrosoftStoreBackend::onProductQuerySucceeded(AbstractProduct * product, const QVariantMap & productData)
+{
+    auto msProduct = qobject_cast<MicrosoftStoreProduct*>(product);
+    if (msProduct) {
+        // Set product data
+        product->setTitle(productData["title"].toString());
+        product->setDescription(productData["description"].toString());
+        product->setPrice(productData["price"].toString());
+
+        // Validate product type matches store configuration
+        QString productKind = productData["productKind"].toString();
+        AbstractProduct::ProductType storeType;
+        if (productKind == "Durable") {
+            storeType = AbstractProduct::Unlockable;
+        } else if (productKind == "UnmanagedConsumable") {
+            storeType = AbstractProduct::Consumable;
+        } else {
+            qCritical() << "Unknown Microsoft Store product kind:" << productKind << "for product:" << product->identifier();
+            product->setStatus(AbstractProduct::Unknown);
+            return;
+        }
+
+        if (storeType != product->productType()) {
+            qCritical() << "Product type mismatch!" << product->identifier()
+            << "Microsoft Store ID:" << productData["storeId"].toString()
+            << "Expected:" << (product->productType() == AbstractProduct::Consumable ? "Consumable" :
+                                   product->productType() == AbstractProduct::Unlockable ? "Unlockable" : "None")
+            << "Store reports:" << productKind;
+            product->setStatus(AbstractProduct::IncorrectProductType);
+            return;
+        }
+
+        // Track the product for later reference
+        _registeredProducts[product->identifier()] = product;
+
+        product->setStatus(AbstractProduct::Registered);
+        emit productRegistered(product);
+
+        qDebug() << "Product registered successfully:" << product->identifier();
+    }
+}
+
+void MicrosoftStoreBackend::onProductQueryFailed(AbstractProduct * product, uint32_t hresult, const QString & message)
+{
+    qWarning() << "Product query failed for:" << product->identifier()
+    << "HRESULT:" << Qt::hex << Qt::showbase << hresult << "Message:" << message;
+    product->setStatus(AbstractProduct::Unknown);
+}
+
+void MicrosoftStoreBackend::onPurchaseComplete(AbstractProduct * product, StorePurchaseStatus status)
+{
+    qDebug() << "onPurchaseComplete: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
+
+    if (!processingEnabled()) {
+        qDebug() << "Windows: onPurchaseComplete received but processing not enabled - queueing";
+        _queuedPurchases.append({product, status});
+        return;
+    }
+
+    processPurchase(product, status);
+}
+
 void MicrosoftStoreBackend::onRestoreSucceeded(const QList<QVariantMap> &restoredProducts)
 {
     qDebug() << "onRestoreSucceeded: Backend thread:" << this->thread() << "Current thread:" << QThread::currentThread();
@@ -397,75 +352,26 @@ void MicrosoftStoreBackend::onRestoreFailed(uint32_t errorCode, const QString & 
     emit restorePurchasesFailed(static_cast<int>(mappedError), errorCode, message);
 }
 
-bool MicrosoftStoreBackend::canMakePurchases() const
+void MicrosoftStoreBackend::onAllProductsQueried(const QList<QVariantMap> &products)
 {
-    // For Windows, we can make purchases if we're connected to the store
-    return isConnected();
-}
-
-AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapWindowsErrorToPurchaseError(uint32_t statusCode)
-{
-    switch (statusCode) {
-        case 0: // StorePurchaseStatus::Succeeded
-            return PurchaseError::NoError;
-        case 1: // StorePurchaseStatus::AlreadyPurchased
-            return PurchaseError::AlreadyPurchased;
-        case 2: // StorePurchaseStatus::NotPurchased
-            return PurchaseError::UserCanceled;
-        case 3: // StorePurchaseStatus::NetworkError
-            return PurchaseError::NetworkError;
-        case 4: // StorePurchaseStatus::ServerError
-            return PurchaseError::ServiceUnavailable;
-        default:
-            return PurchaseError::UnknownError;
+    qDebug() << "Store query completed, found" << products.size() << "products";
+    for (const auto& product : products) {
+        qDebug() << "Available product:" << product["productId"].toString()
+        << "Title:" << product["title"].toString();
     }
+
+    // Now that products are available, restore existing purchases
+    qDebug() << "Products queried, now calling restorePurchases()";
+    restorePurchases();
 }
 
-QString MicrosoftStoreBackend::getWindowsErrorMessage(uint32_t statusCode)
+void MicrosoftStoreBackend::onAllProductsQueryFailed(uint32_t hresult, const QString & message)
 {
-    switch (statusCode) {
-        case 0: // StorePurchaseStatus::Succeeded
-            return "Purchase completed successfully";
-        case 1: // StorePurchaseStatus::AlreadyPurchased
-            return "User already owns this item";
-        case 2: // StorePurchaseStatus::NotPurchased
-            return "Purchase was not completed (user canceled or payment failed)";
-        case 3: // StorePurchaseStatus::NetworkError
-            return "Network connection failed during purchase";
-        case 4: // StorePurchaseStatus::ServerError
-            return "Microsoft Store server error occurred";
-        default:
-            return QString("Unknown Windows StorePurchaseStatus: %1").arg(statusCode);
-    }
-}
-
-AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapHRESULTToPurchaseError(uint32_t hresult)
-{
-    switch (hresult) {
-        case 0x80070525: // ERROR_NO_SUCH_USER
-            return PurchaseError::NotAllowed;
-        case 0x803F6107: // Store licensing error
-            return PurchaseError::DeveloperError;
-        case 0x80072EFD: // WININET_E_CANNOT_CONNECT (network connectivity)
-            return PurchaseError::NetworkError;
-        case 0x80004005: // E_FAIL (generic failure)
-            return PurchaseError::UnknownError;
-        case 0x80070005: // E_ACCESSDENIED (access denied)
-            return PurchaseError::ServiceUnavailable;
-        default:
-            return PurchaseError::UnknownError;
-    }
-}
-
-void MicrosoftStoreBackend::enableProcessing()
-{
-    if (processingEnabled())
-        return;
-
-    AbstractStoreBackend::enableProcessing();
-
-    qDebug() << "Windows: Processing enabled - processing queued transactions";
-    processQueuedTransactions();
+    qWarning() << "Failed to query all products - HRESULT:" << Qt::hex << Qt::showbase << hresult
+               << "Message:" << message;
+    // Continue anyway - this is just diagnostic info
+    // Still try to restore purchases even if we couldn't enumerate products
+    restorePurchases();
 }
 
 void MicrosoftStoreBackend::processQueuedTransactions()
@@ -529,4 +435,98 @@ void MicrosoftStoreBackend::processRestoredProducts(const QList<QVariantMap> &re
     }
 
     emit restorePurchasesSucceeded(restoredCount);
+}
+
+void MicrosoftStoreBackend::initializeWindowHandle()
+{
+    auto app = qobject_cast<QGuiApplication*>(QCoreApplication::instance());
+    if (!app) {
+        qDebug() << "No QGuiApplication instance found";
+        return;
+    }
+
+    auto windows = app->topLevelWindows();
+    if (!windows.isEmpty()) {
+        auto window = windows.first();
+        if (window) {
+            // For QWindow, we just get the winId which creates the native window
+            _hwnd = reinterpret_cast<HWND>(window->winId());
+            qDebug() << "Cached window handle:" << _hwnd;
+        }
+    }
+}
+
+void MicrosoftStoreBackend::queryAllProducts()
+{
+    if (!_hwnd) {
+        qWarning() << "No window handle available for Store query";
+        return;
+    }
+
+    auto* worker = new StoreAllProductsWorker(_hwnd);
+    auto* thread = new QThread(this);
+
+    worker->moveToThread(thread);
+    connect(thread, &QThread::started, worker, &StoreAllProductsWorker::performQuery);
+    connect(worker, &StoreAllProductsWorker::querySucceeded, this, &MicrosoftStoreBackend::onAllProductsQueried, Qt::QueuedConnection);
+    connect(worker, &StoreAllProductsWorker::queryFailed, this, &MicrosoftStoreBackend::onAllProductsQueryFailed, Qt::QueuedConnection);
+    connect(worker, &StoreAllProductsWorker::finished, thread, &QThread::quit);
+    connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+    connect(worker, &StoreAllProductsWorker::finished, worker, &StoreAllProductsWorker::deleteLater);
+
+    thread->start();
+}
+
+AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapWindowsErrorToPurchaseError(uint32_t statusCode)
+{
+    switch (statusCode) {
+        case 0: // StorePurchaseStatus::Succeeded
+            return PurchaseError::NoError;
+        case 1: // StorePurchaseStatus::AlreadyPurchased
+            return PurchaseError::AlreadyPurchased;
+        case 2: // StorePurchaseStatus::NotPurchased
+            return PurchaseError::UserCanceled;
+        case 3: // StorePurchaseStatus::NetworkError
+            return PurchaseError::NetworkError;
+        case 4: // StorePurchaseStatus::ServerError
+            return PurchaseError::ServiceUnavailable;
+        default:
+            return PurchaseError::UnknownError;
+    }
+}
+
+QString MicrosoftStoreBackend::getWindowsErrorMessage(uint32_t statusCode)
+{
+    switch (statusCode) {
+        case 0: // StorePurchaseStatus::Succeeded
+            return "Purchase completed successfully";
+        case 1: // StorePurchaseStatus::AlreadyPurchased
+            return "User already owns this item";
+        case 2: // StorePurchaseStatus::NotPurchased
+            return "Purchase was not completed (user canceled or payment failed)";
+        case 3: // StorePurchaseStatus::NetworkError
+            return "Network connection failed during purchase";
+        case 4: // StorePurchaseStatus::ServerError
+            return "Microsoft Store server error occurred";
+        default:
+            return QString("Unknown Windows StorePurchaseStatus: %1").arg(statusCode);
+    }
+}
+
+AbstractStoreBackend::PurchaseError MicrosoftStoreBackend::mapHRESULTToPurchaseError(uint32_t hresult)
+{
+    switch (hresult) {
+        case 0x80070525: // ERROR_NO_SUCH_USER
+            return PurchaseError::NotAllowed;
+        case 0x803F6107: // Store licensing error
+            return PurchaseError::DeveloperError;
+        case 0x80072EFD: // WININET_E_CANNOT_CONNECT (network connectivity)
+            return PurchaseError::NetworkError;
+        case 0x80004005: // E_FAIL (generic failure)
+            return PurchaseError::UnknownError;
+        case 0x80070005: // E_ACCESSDENIED (access denied)
+            return PurchaseError::ServiceUnavailable;
+        default:
+            return PurchaseError::UnknownError;
+    }
 }

--- a/src/windows/microsoftstorebackend.h
+++ b/src/windows/microsoftstorebackend.h
@@ -32,11 +32,13 @@ protected:
     void restorePurchasesImpl() override;
 
 private slots:
-    void onProductQueried(AbstractProduct * product, bool success, const QVariantMap & productData);
+    void onProductQuerySucceeded(AbstractProduct * product, const QVariantMap & productData);
+    void onProductQueryFailed(AbstractProduct * product, uint32_t hresult, const QString & message);
     void onPurchaseComplete(AbstractProduct * product, winrt::Windows::Services::Store::StorePurchaseStatus status);
-    void onRestoreComplete(const QList<QVariantMap> &restoredProducts);
+    void onRestoreSucceeded(const QList<QVariantMap> &restoredProducts);
     void onRestoreFailed(uint32_t errorCode, const QString & message);
     void onAllProductsQueried(const QList<QVariantMap> &products);
+    void onAllProductsQueryFailed(uint32_t hresult, const QString & message);
 
 private:
     HWND _hwnd = nullptr;
@@ -57,9 +59,9 @@ private:
 
     void initializeWindowHandle();
     void queryAllProducts();
-    void onConsumableFulfillmentComplete(const QString & orderId, const QString & productId, bool success, const QString & result);
     static PurchaseError mapWindowsErrorToPurchaseError(uint32_t errorCode);
     static QString getWindowsErrorMessage(uint32_t errorCode);
+    static PurchaseError mapHRESULTToPurchaseError(uint32_t hresult);
 };
 
 #endif // MICROSOFTSTOREBACKEND_H

--- a/src/windows/microsoftstorebackend.h
+++ b/src/windows/microsoftstorebackend.h
@@ -45,17 +45,16 @@ private:
     QMap<QString, AbstractProduct *> _registeredProducts; // Track products by identifier
 
     void processQueuedTransactions();
+    void processPurchase(AbstractProduct * product, winrt::Windows::Services::Store::StorePurchaseStatus status);
+    void processRestoredProducts(const QList<QVariantMap> &restoredProducts);
 
     // Queued transaction data
     struct QueuedPurchase {
         AbstractProduct* product;
         winrt::Windows::Services::Store::StorePurchaseStatus status;
     };
-    struct QueuedRestore {
-        QList<QVariantMap> restoredProducts;
-    };
     QList<QueuedPurchase> _queuedPurchases;
-    QList<QueuedRestore> _queuedRestores;
+    QList<QVariantMap> _queuedRestores;
 
     void initializeWindowHandle();
     void queryAllProducts();

--- a/src/windows/microsoftstoreworkers.cpp
+++ b/src/windows/microsoftstoreworkers.cpp
@@ -47,11 +47,11 @@ void StoreProductQueryWorker::performQuery()
         
         if (!result.ExtendedError()) {
             auto products = result.Products();
-            
+
             if (products.Size() > 0) {
                 // Get the first (and should be only) product
                 auto storeProduct = products.First().Current().Value();
-                
+
                 QVariantMap productData;
                 productData["storeId"] = QString::fromWCharArray(storeProduct.StoreId().c_str());
                 productData["title"] = QString::fromWCharArray(storeProduct.Title().c_str());
@@ -59,22 +59,25 @@ void StoreProductQueryWorker::performQuery()
                 productData["price"] = QString::fromWCharArray(storeProduct.Price().FormattedPrice().c_str());
                 productData["productKind"] = QString::fromWCharArray(storeProduct.ProductKind().c_str());
                 productData["isInUserCollection"] = storeProduct.IsInUserCollection();
-                
-                emit queryComplete(true, productData);
+
+                emit querySucceeded(productData);
             } else {
                 qDebug() << "Product not found in store:" << _productId;
-                emit queryComplete(false, QVariantMap());
+                emit queryFailed(0, "Product not found in store");
             }
         } else {
-            qWarning() << "Store query error:" << Qt::hex << result.ExtendedError().value;
-            emit queryComplete(false, QVariantMap());
+            uint32_t hresult = result.ExtendedError().value;
+            qWarning() << "Store query error for product" << _productId << "- HRESULT:" << Qt::hex << Qt::showbase << hresult;
+            emit queryFailed(hresult, QString("Store API error: 0x%1").arg(hresult, 0, 16));
         }
     } catch (const winrt::hresult_error& e) {
-        qWarning() << "Exception in product query:" << QString::fromWCharArray(e.message().c_str());
-        emit queryComplete(false, QVariantMap());
+        uint32_t hresult = static_cast<uint32_t>(e.code().value);
+        QString message = QString::fromWCharArray(e.message().c_str());
+        qWarning() << "Exception in product query:" << message << "HRESULT:" << Qt::hex << Qt::showbase << hresult;
+        emit queryFailed(hresult, message);
     } catch (...) {
         qWarning() << "Unknown exception in product query";
-        emit queryComplete(false, QVariantMap());
+        emit queryFailed(0x80004005, "Unknown exception");
     }
     
     emit finished();
@@ -136,11 +139,11 @@ void StoreRestoreWorker::performRestore()
 
                 restoredProducts.append(productData);
             }
-            emit restoreComplete(restoredProducts);
+            emit restoreSucceeded(restoredProducts);
         } else {
-            uint32_t errorCode = result.ExtendedError().value;
-            qWarning() << "Windows Store restore error:" << Qt::hex << errorCode;
-            emit restoreFailed(errorCode, QString("Windows Store API error: 0x%1").arg(errorCode, 0, 16));
+            uint32_t hresult = result.ExtendedError().value;
+            qWarning() << "Windows Store restore error - HRESULT:" << Qt::hex << Qt::showbase << hresult;
+            emit restoreFailed(hresult, QString("Windows Store API error: 0x%1").arg(hresult, 0, 16));
         }
     } catch (const winrt::hresult_error& e) {
         uint32_t errorCode = static_cast<uint32_t>(e.code().value);
@@ -173,10 +176,10 @@ void StoreAllProductsWorker::performQuery()
         
         if (!result.ExtendedError()) {
             auto storeProducts = result.Products();
-            
+
             for (auto const& item : storeProducts) {
                 auto storeProduct = item.Value();
-                
+
                 QVariantMap productData;
                 productData["storeId"] = QString::fromWCharArray(storeProduct.StoreId().c_str());
                 productData["productId"] = QString::fromWCharArray(item.Key().c_str());
@@ -184,22 +187,25 @@ void StoreAllProductsWorker::performQuery()
                 productData["description"] = QString::fromWCharArray(storeProduct.Description().c_str());
                 productData["price"] = QString::fromWCharArray(storeProduct.Price().FormattedPrice().c_str());
                 productData["productKind"] = QString::fromWCharArray(storeProduct.ProductKind().c_str());
-                
+
                 products.append(productData);
             }
-            
+
             qDebug() << "Found" << products.size() << "associated products";
+            emit querySucceeded(products);
         } else {
-            qWarning() << "Error querying all products:" << Qt::hex << result.ExtendedError().value;
+            uint32_t hresult = result.ExtendedError().value;
+            qWarning() << "Error querying all products - HRESULT:" << Qt::hex << Qt::showbase << hresult;
+            emit queryFailed(hresult, QString("Store API error: 0x%1").arg(hresult, 0, 16));
         }
-        
-        emit queryComplete(products);
     } catch (const winrt::hresult_error& e) {
-        qWarning() << "Exception querying all products:" << QString::fromWCharArray(e.message().c_str());
-        emit queryComplete(QList<QVariantMap>());
+        uint32_t hresult = static_cast<uint32_t>(e.code().value);
+        QString message = QString::fromWCharArray(e.message().c_str());
+        qWarning() << "Exception querying all products:" << message << "HRESULT:" << Qt::hex << Qt::showbase << hresult;
+        emit queryFailed(hresult, message);
     } catch (...) {
         qWarning() << "Unknown exception querying all products";
-        emit queryComplete(QList<QVariantMap>());
+        emit queryFailed(0x80004005, "Unknown exception");
     }
     
     emit finished();
@@ -232,30 +238,32 @@ void StoreConsumableFulfillmentWorker::performFulfillment()
         switch (result.Status()) {
             case StoreConsumableStatus::Succeeded:
                 qDebug() << "Consumable fulfillment succeeded, balance:" << result.BalanceRemaining();
-                emit fulfillmentComplete(true, "Success");
+                emit fulfillmentSucceeded();
                 break;
             case StoreConsumableStatus::InsufficentQuantity:
                 qWarning() << "Consumable fulfillment failed: Insufficient quantity";
-                emit fulfillmentComplete(false, "InsufficientQuantity");
+                emit fulfillmentFailed(static_cast<uint32_t>(StoreConsumableStatus::InsufficentQuantity), "Insufficient quantity");
                 break;
             case StoreConsumableStatus::NetworkError:
                 qWarning() << "Consumable fulfillment failed: Network error";
-                emit fulfillmentComplete(false, "NetworkError");
+                emit fulfillmentFailed(static_cast<uint32_t>(StoreConsumableStatus::NetworkError), "Network error");
                 break;
             case StoreConsumableStatus::ServerError:
                 qWarning() << "Consumable fulfillment failed: Server error";
-                emit fulfillmentComplete(false, "ServerError");
+                emit fulfillmentFailed(static_cast<uint32_t>(StoreConsumableStatus::ServerError), "Server error");
                 break;
             default:
                 qWarning() << "Consumable fulfillment failed: Unknown error";
-                emit fulfillmentComplete(false, "UnknownError");
+                emit fulfillmentFailed(0x80004005, "Unknown fulfillment status");
         }
     } catch (const winrt::hresult_error& e) {
-        qWarning() << "Exception in consumable fulfillment:" << QString::fromWCharArray(e.message().c_str());
-        emit fulfillmentComplete(false, QString::fromWCharArray(e.message().c_str()));
+        uint32_t hresult = static_cast<uint32_t>(e.code().value);
+        QString message = QString::fromWCharArray(e.message().c_str());
+        qWarning() << "Exception in consumable fulfillment:" << message << "HRESULT:" << Qt::hex << Qt::showbase << hresult;
+        emit fulfillmentFailed(hresult, message);
     } catch (...) {
         qWarning() << "Unknown exception in consumable fulfillment";
-        emit fulfillmentComplete(false, "Unknown exception");
+        emit fulfillmentFailed(0x80004005, "Unknown exception");
     }
     
     emit finished();

--- a/src/windows/microsoftstoreworkers.h
+++ b/src/windows/microsoftstoreworkers.h
@@ -34,7 +34,8 @@ public slots:
     void performQuery();
 
 signals:
-    void queryComplete(bool success, const QVariantMap &productData);
+    void querySucceeded(const QVariantMap &productData);
+    void queryFailed(uint32_t hresult, const QString &message);
     void finished();
 
 private:
@@ -72,7 +73,7 @@ public slots:
     void performRestore();
 
 signals:
-    void restoreComplete(const QList<QVariantMap> &restoredProducts);
+    void restoreSucceeded(const QList<QVariantMap> &restoredProducts);
     void restoreFailed(uint32_t errorCode, const QString & message);
     void finished();
 };
@@ -89,7 +90,8 @@ public slots:
     void performQuery();
 
 signals:
-    void queryComplete(const QList<QVariantMap> &products);
+    void querySucceeded(const QList<QVariantMap> &products);
+    void queryFailed(uint32_t hresult, const QString &message);
     void finished();
 };
 
@@ -105,7 +107,8 @@ public slots:
     void performFulfillment();
 
 signals:
-    void fulfillmentComplete(bool success, const QString &result);
+    void fulfillmentSucceeded();
+    void fulfillmentFailed(uint32_t errorCode, const QString &message);
     void finished();
 
 private:


### PR DESCRIPTION
## Error handling

- **iOS**: Handle additional error codes.
- **Windows**: Handle exception errors too (and tidy up signal naming to match library conventions within worker classes).

## Restore purchases fixes

- Fix: Windows wasn't emitting `restorePurchasesSucceeded` if restores were queued.
- README corrections regarding restore purchases (Windows) and queued transactions (iOS).