### PR TITLE
Refinements to store set up and product registration

### DIFF
--- a/src/android/GooglePlayBilling.java
+++ b/src/android/GooglePlayBilling.java
@@ -19,6 +19,7 @@ public class GooglePlayBilling {
     private static native void connectedChangedHelper(boolean connected);
     private static native void billingResponseReceived(int billingResponseCode);
     private static native void productRegistered(String productJson);
+    private static native void productRegistrationFailed(String productId, int billingResponseCode);
 
     private static native void purchaseSucceeded(String purchaseJson);
     private static native void purchasePending(String purchaseJson);
@@ -127,11 +128,18 @@ public class GooglePlayBilling {
                 @Override
                 public void onSkuDetailsResponse(BillingResult billingResult,
                         List<SkuDetails> skuDetailsList) {
-                    if (skuDetailsList == null)
-//                        throw new NullPointerException("skuDetailsList is null");
-                        return;
-
                     billingResponseReceived(billingResult.getResponseCode());
+
+                    if (billingResult.getResponseCode() != BillingResponseCode.OK) {
+                        productRegistrationFailed(productId, billingResult.getResponseCode());
+                        return;
+                    }
+
+                    if (skuDetailsList == null || skuDetailsList.isEmpty()) {
+                        productRegistrationFailed(productId, BillingResponseCode.OK);
+                        return;
+                    }
+
                     productRegistered(skuDetailsList.get(0).getOriginalJson());
                 }
             });

--- a/src/android/googleplaystorebackend.cpp
+++ b/src/android/googleplaystorebackend.cpp
@@ -42,6 +42,7 @@ GooglePlayStoreBackend::GooglePlayStoreBackend(QObject * parent) : AbstractStore
         {"billingResponseReceived", "(I)V", reinterpret_cast<void *>(billingResponseReceived)},
         {"connectedChangedHelper", "(Z)V", reinterpret_cast<void *>(connectedChangedHelper)},
         {"productRegistered", "(Ljava/lang/String;)V", reinterpret_cast<void *>(productRegistered)},
+        {"productRegistrationFailed", "(Ljava/lang/String;I)V", reinterpret_cast<void *>(productRegistrationFailed)},
         {"purchaseSucceeded", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseSucceeded)},
         {"purchasePending", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchasePending)},
         {"purchaseRestored", "(Ljava/lang/String;)V", reinterpret_cast<void *>(purchaseRestored)},
@@ -133,6 +134,27 @@ void GooglePlayStoreBackend::registerProduct(AbstractProduct * product)
     } else {
         qCritical() << "Registered a product that's not in the list of products. This is not handled.";
     }
+}
+
+/*static*/ void GooglePlayStoreBackend::productRegistrationFailed(JNIEnv *env, jobject object, jstring productId, jint billingResponseCode)
+{
+    GooglePlayStoreBackend * backend = GooglePlayStoreBackend::s_currentInstance;
+    if (!backend) {
+        qCritical() << "Google Play product registration failed callback received but backend instance is null";
+        return;
+    }
+
+    const char* productIdCStr = env->GetStringUTFChars(productId, nullptr);
+    QString prodId = QString::fromUtf8(productIdCStr);
+    env->ReleaseStringUTFChars(productId, productIdCStr);
+
+    qWarning() << "Product registration failed for" << prodId << "with billing response code:" << billingResponseCode;
+
+    AbstractProduct * product = backend->product(prodId);
+    if (product)
+        product->setStatus(AbstractProduct::Unknown);
+    else
+        qWarning() << "Could not find product to update status:" << prodId;
 }
 
 void GooglePlayStoreBackend::purchaseProduct(AbstractProduct * product)

--- a/src/android/googleplaystorebackend.h
+++ b/src/android/googleplaystorebackend.h
@@ -36,6 +36,7 @@ public:
     static void billingResponseReceived(JNIEnv * env, jobject object, jint billingResponseCode);
     static void connectedChangedHelper(JNIEnv * env, jobject object, jboolean connected);
     static void productRegistered(JNIEnv * env, jobject object, jstring productJson);
+    static void productRegistrationFailed(JNIEnv * env, jobject object, jstring productId, jint billingResponseCode);
     static void purchaseSucceeded(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchasePending(JNIEnv * env, jobject object, jstring purchaseJson);
     static void purchaseRestored(JNIEnv * env, jobject object, jstring purchaseJson);

--- a/src/apple/appleappstorebackend.mm
+++ b/src/apple/appleappstorebackend.mm
@@ -420,7 +420,7 @@ void AppleAppStoreBackend::restorePurchasesImpl()
 
 bool AppleAppStoreBackend::canMakePurchases() const
 {
-    return [SKPaymentQueue canMakePayments];
+    return isConnected() && [SKPaymentQueue canMakePayments];
 }
 
 void AppleAppStoreBackend::enableProcessing()


### PR DESCRIPTION
- On Windows & Android `canMakePayments` was dependent on `connected`. Now Apple matches this.
- On Android, when product registration failed, it would leave the product in a pending state. Now fixed.